### PR TITLE
Add `tiny-aya-global` as a supported LLM backbone

### DIFF
--- a/config/lora_config.py
+++ b/config/lora_config.py
@@ -1,16 +1,17 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from peft import LoraConfig, TaskType
 
-# Tiny Aya Base has 36 transformer layers (indices 0–35).
-# "Mid-to-top" targets the upper half: layers 18–35.
-_NUM_LLM_LAYERS = 36
-_FIRST_MID_LAYER = _NUM_LLM_LAYERS // 2  # 18
+if TYPE_CHECKING:
+    from config.model_config import TinyAyaVisionConfig
 
 
 @dataclass
 class LoraAdapterConfig:
-    """LoRA adapter configuration for the Tiny Aya Base (Cohere2) backbone.
+    """LoRA adapter configuration for the Tiny Aya (Cohere2) backbone.
 
     LoRA injects trainable rank-decomposition matrices A (down) and B (up) into
     frozen linear layers. Only the injected adapter weights are updated during
@@ -47,17 +48,32 @@ class LoraAdapterConfig:
         ]
     )
 
-    # Layer indices to inject LoRA into (mid-to-top: layers 18–35 of 36 total).
+    # Layer indices to inject LoRA into (mid-to-top: upper half of total layers).
     # Lower layers encode general language/multilingual knowledge that we want
     # to preserve; upper layers are more task-specific and benefit from adaptation.
+    # Default targets layers 18–35 of 36 total (Cohere2 with 36 layers).
     layers_to_transform: list[int] = field(
-        default_factory=lambda: list(range(_FIRST_MID_LAYER, _NUM_LLM_LAYERS))
+        default_factory=lambda: list(range(18, 36))
     )
 
     # Differential LR multipliers for A and B matrices.
     # Set both to 1.0 to use a uniform LR for all adapter parameters.
     lora_a_lr_multiplier: float = 1.0
     lora_b_lr_multiplier: float = 1.0
+
+    @classmethod
+    def from_vlm_config(
+        cls, vlm_config: TinyAyaVisionConfig, **kwargs
+    ) -> LoraAdapterConfig:
+        """Build a LoraAdapterConfig targeting the upper half of the LLM's layers.
+
+        Derives layer indices from vlm_config.num_llm_layers so the config
+        stays correct regardless of which Tiny Aya variant is used.
+        """
+        num_layers = vlm_config.num_llm_layers
+        first_mid = num_layers // 2
+        layers = list(range(first_mid, num_layers))
+        return cls(layers_to_transform=layers, **kwargs)
 
     def to_peft_config(self) -> LoraConfig:
         """Return a PEFT LoraConfig ready for use with get_peft_model()."""

--- a/config/model_config.py
+++ b/config/model_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 
@@ -23,10 +25,11 @@ class TinyAyaVisionConfig:
     connector_intermediate_size: int = 2048  # matches LLM hidden_size
     adapter_layer_norm_eps: float = 1e-6
 
-    # LLM backbone (Tiny Aya Base)
+    # LLM backbone
     llm_model_name: str = "CohereLabs/tiny-aya-base"
     llm_hidden_size: int = 2048
     llm_vocab_size: int = 262144
+    num_llm_layers: int = 36  # Cohere2: 36 transformer layers
 
     # Special tokens
     image_token: str = "<image>"
@@ -38,3 +41,13 @@ class TinyAyaVisionConfig:
     vision_feature_layer: int = -1
     # "full" = all patches, "default" = crop CLS
     vision_feature_select_strategy: str = "full"
+
+    @classmethod
+    def for_base(cls) -> TinyAyaVisionConfig:
+        """Config for CohereLabs/tiny-aya-base (pretrained base model)."""
+        return cls(llm_model_name="CohereLabs/tiny-aya-base")
+
+    @classmethod
+    def for_global(cls) -> TinyAyaVisionConfig:
+        """Config for CohereLabs/tiny-aya-global (instruction-tuned, best multilingual balance)."""
+        return cls(llm_model_name="CohereLabs/tiny-aya-global")

--- a/scripts/apply_lora.py
+++ b/scripts/apply_lora.py
@@ -28,7 +28,6 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-import torch
 import torch.nn as nn
 from peft import get_peft_model
 
@@ -190,20 +189,39 @@ def main() -> None:
     parser.add_argument(
         "--layers-start",
         type=int,
-        default=18,
-        help="First LLM layer index to apply LoRA (default: 18).",
+        default=None,
+        help="First LLM layer index to apply LoRA (default: num_llm_layers // 2).",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="base",
+        choices=["base", "global"],
+        help="Which Tiny Aya LLM backbone to use (default: base).",
     )
     args = parser.parse_args()
 
+    vlm_config = (
+        TinyAyaVisionConfig.for_global()
+        if args.model == "global"
+        else TinyAyaVisionConfig.for_base()
+    )
+
     alpha = args.alpha if args.alpha is not None else args.rank * 2
+    layers_start = (
+        args.layers_start
+        if args.layers_start is not None
+        else vlm_config.num_llm_layers // 2
+    )
 
     lora_config = LoraAdapterConfig(
         rank=args.rank,
         lora_alpha=alpha,
-        layers_to_transform=list(range(args.layers_start, 36)),
+        layers_to_transform=list(range(layers_start, vlm_config.num_llm_layers)),
     )
 
-    print(f"LoRA config:")
+    print(f"Model: {vlm_config.llm_model_name}")
+    print("LoRA config:")
     print(f"  rank={lora_config.rank}, alpha={lora_config.lora_alpha} "
           f"(scale={lora_config.lora_alpha / lora_config.rank:.1f})")
     print(f"  layers: {lora_config.layers_to_transform[0]}–"
@@ -211,7 +229,6 @@ def main() -> None:
           f"({len(lora_config.layers_to_transform)} layers)")
     print(f"  target modules: {lora_config.target_modules}")
 
-    vlm_config = TinyAyaVisionConfig()
     model = apply_lora(vlm_config, lora_config)
     print_param_summary(model)
 

--- a/tests/test_vlm_assembly.py
+++ b/tests/test_vlm_assembly.py
@@ -13,11 +13,19 @@ class TestVLMAssembly:
 
     These tests require GPU and download both models (~7.5GB in bf16).
     Run with: pytest tests/test_vlm_assembly.py -v
+
+    Parametrized over both LLM backbones:
+      - "base"   → CohereLabs/tiny-aya-base   (pretrained)
+      - "global" → CohereLabs/tiny-aya-global (instruction-tuned)
     """
 
-    @pytest.fixture(scope="class")
-    def model_and_processor(self):
-        config = TinyAyaVisionConfig()
+    @pytest.fixture(scope="class", params=["base", "global"])
+    def model_and_processor(self, request):
+        config = (
+            TinyAyaVisionConfig.for_global()
+            if request.param == "global"
+            else TinyAyaVisionConfig.for_base()
+        )
         model = TinyAyaVisionForConditionalGeneration(config)
         processor = TinyAyaVisionProcessor(config)
         model.setup_tokenizer(processor.tokenizer)


### PR DESCRIPTION
## Summary

- Add `TinyAyaVisionConfig.for_base()` and `TinyAyaVisionConfig.for_global()` named presets for selecting the LLM backbone
- Add `num_llm_layers` field to `TinyAyaVisionConfig` as the authoritative layer count for LoRA targeting
- Add `LoraAdapterConfig.from_vlm_config()` factory to derive layers_to_transform from the model config instead of hardcoded constants
- Add `--model base|global` flag to `scripts/apply_lora.py`; `--layers-start` now defaults to `num_llm_layers // 2`
- Parametrize `TestVLMAssembly` GPU tests over both backbones

## Background

`CohereLabs/tiny-aya-global` is the instruction-tuned (SFT + preference-trained) variant of `tiny-aya-base`, with the best balance across 70+ languages. It shares the same Cohere2 architecture (36 layers, hidden_size=2048, vocab_size=262144), confirmed via `AutoConfig.from_pretrained`. As a result, no changes were needed in the vision encoder, connector, processor, or model assembly (only configuration and the LoRA setup script required updates).

## Test plan
 - [x] CPU-only tests still pass: `pytest tests/test_connector.py tests/test_processing.py -v`
 - [x] GPU tests pass for both backbones: `pytest tests/test_vlm_assembly.py -v`
 - [x] LoRA script works for global: `uv run python scripts/apply_lora.py --model global --rank 256`