### PR TITLE
Update GPU selection method in training scripts and documentation

### DIFF
--- a/docs/training_vision_encoders_experiment.md
+++ b/docs/training_vision_encoders_experiment.md
@@ -72,7 +72,7 @@ Key concepts:
 - **`modal.Volume`** — persistent disk attached to your function (survives across runs)
 - **`modal.Secret`** — securely injects env vars like `HF_TOKEN` and `WANDB_API_KEY`
 - **`--detach`** — runs the job in the background so you can close your terminal
-- **GPU selection** — pass `--gpu A10G` or `--gpu A100` to the training script
+- **GPU selection** — set via the `MODAL_GPU` env var (e.g. `MODAL_GPU=A100-80GB`). Defaults to `A10G`
 
 ---
 
@@ -113,16 +113,16 @@ This downloads the 558k conversation JSON and ~13GB of images directly onto the 
 
 ### Step 3: Run Alignment Training
 
-Train with **SigLIP** on an A10G:
+Train with **SigLIP** (default A10G):
 
 ```bash
-modal run --detach scripts/modal_train_alignment.py --vision siglip --gpu A10G
+modal run --detach scripts/modal_train_alignment.py --vision siglip
 ```
 
-Train with **MoonViT** on an A100:
+Train with **MoonViT** on an A100-80GB:
 
 ```bash
-modal run --detach scripts/modal_train_alignment.py --vision moonvit --gpu A100
+MODAL_GPU=A100-80GB modal run --detach scripts/modal_train_alignment.py --vision moonvit
 ```
 
 Available flags:
@@ -131,8 +131,14 @@ Available flags:
 |------|---------|-------------|
 | `--vision` | `moonvit` | Vision encoder: `siglip` or `moonvit` |
 | `--llm` | `base` | LLM variant: `base` or `global` |
-| `--gpu` | `A100` | GPU type: `A10G`, `A100`, `H100`, etc. |
 | `--resume-run-id` | `None` | Resume from a previous run's checkpoint |
+
+To change the GPU, set the `MODAL_GPU` env var (defaults to `A10G`):
+
+```bash
+MODAL_GPU=A100-80GB modal run --detach scripts/modal_train_alignment.py --vision moonvit
+MODAL_GPU=H100   modal run --detach scripts/modal_train_alignment.py --vision siglip
+```
 
 Resume a previous run:
 

--- a/scripts/modal_train_alignment.py
+++ b/scripts/modal_train_alignment.py
@@ -3,12 +3,18 @@ Run alignment training on Modal.
 
 Usage:
     modal run --detach scripts/modal_train_alignment.py
-    modal run --detach scripts/modal_train_alignment.py --vision siglip --gpu A10G
-    modal run --detach scripts/modal_train_alignment.py --vision moonvit --gpu A100
+    modal run --detach scripts/modal_train_alignment.py --vision siglip
+    MODAL_GPU=A100-80GB modal run --detach scripts/modal_train_alignment.py --vision moonvit
     modal run --detach scripts/modal_train_alignment.py --resume-run-id <id>
 """
 
+import os
+
 import modal
+
+# Read GPU from MODAL_GPU env var so it can be set before the app is created.
+# Usage: MODAL_GPU=A100-80GB modal run --detach scripts/modal_train_alignment.py --vision moonvit
+GPU = os.environ.get("MODAL_GPU", "A10G")
 
 app = modal.App("tayavision-train-alignment")
 volume = modal.Volume.from_name("tayavision-data")
@@ -41,31 +47,29 @@ image = (
 )
 
 
-@app.cls(
+@app.function(
     image=image,
-    gpu="A10G",
+    gpu=GPU,
     volumes={"/data": volume, "/models": models_volume},
     secrets=[modal.Secret.from_name("huggingface"), modal.Secret.from_name("wandb")],
     timeout=3600 * 24,
 )
-class Trainer:
-    @modal.method()
-    def train(self, vision: str = "moonvit", llm: str = "base", resume_run_id: str | None = None):
-        import sys
-        sys.path.insert(0, "/root/project")
+def train(vision: str = "moonvit", llm: str = "base", resume_run_id: str | None = None):
+    import sys
+    sys.path.insert(0, "/root/project")
 
-        from hydra import compose, initialize_config_dir
-        from pipeline.train_alignment import run
+    from hydra import compose, initialize_config_dir
+    from pipeline.train_alignment import run
 
-        overrides = [f"vision={vision}", f"llm={llm}"]
-        if resume_run_id:
-            overrides.append(f"resume={resume_run_id}")
+    overrides = [f"vision={vision}", f"llm={llm}"]
+    if resume_run_id:
+        overrides.append(f"resume={resume_run_id}")
 
-        with initialize_config_dir(config_dir="/root/project/config", version_base="1.3"):
-            cfg = compose(config_name="config", overrides=overrides)
-            run(cfg)
+    with initialize_config_dir(config_dir="/root/project/config", version_base="1.3"):
+        cfg = compose(config_name="config", overrides=overrides)
+        run(cfg)
 
 
 @app.local_entrypoint()
-def main(vision: str = "moonvit", llm: str = "base", resume_run_id: str = None, gpu: str = "A100"):
-    Trainer.with_options(gpu=gpu)().train.remote(vision=vision, llm=llm, resume_run_id=resume_run_id)
+def main(vision: str = "moonvit", llm: str = "base", resume_run_id: str = None):
+    train.remote(vision=vision, llm=llm, resume_run_id=resume_run_id)


### PR DESCRIPTION
This pull request updates the process for selecting GPU types for training vision encoders, moving from a command-line argument (`--gpu`) to using the `MODAL_GPU` environment variable. The documentation and training script are updated for clarity and consistency, and the script is simplified by removing unnecessary abstractions.

**GPU selection improvements:**
* Replaced the `--gpu` command-line argument with the `MODAL_GPU` environment variable for specifying GPU type in both documentation and the `scripts/modal_train_alignment.py` script. The default GPU is now `A10G`. [[1]](diffhunk://#diff-39972b318c5623ee2016cbd9c92b05c48d7c20d676e534d3a1e16bc8a4dee202L75-R75) [[2]](diffhunk://#diff-39972b318c5623ee2016cbd9c92b05c48d7c20d676e534d3a1e16bc8a4dee202L116-R125) [[3]](diffhunk://#diff-39972b318c5623ee2016cbd9c92b05c48d7c20d676e534d3a1e16bc8a4dee202L134-R142) [[4]](diffhunk://#diff-ad084dc4a93e930d4a2bba8261aa907e4c8ec38677faa4213e2ac1287566a6dbL6-R18)
* Updated example commands and documentation to demonstrate the new `MODAL_GPU` usage instead of the old `--gpu` flag. [[1]](diffhunk://#diff-39972b318c5623ee2016cbd9c92b05c48d7c20d676e534d3a1e16bc8a4dee202L116-R125) [[2]](diffhunk://#diff-39972b318c5623ee2016cbd9c92b05c48d7c20d676e534d3a1e16bc8a4dee202L134-R142) [[3]](diffhunk://#diff-ad084dc4a93e930d4a2bba8261aa907e4c8ec38677faa4213e2ac1287566a6dbL6-R18)

**Code simplification and cleanup:**
* Removed the `Trainer` class and associated `@app.cls` usage in favor of a direct `@app.function`, simplifying the training function definition and invocation.
* Updated the local entrypoint to match the new function signature and removed the now-unnecessary `gpu` parameter.