### PR TITLE
add chat template support for stage 1

### DIFF
--- a/pipeline/data.py
+++ b/pipeline/data.py
@@ -38,17 +38,31 @@ class AlignmentDataset(torch.utils.data.Dataset):
         prompt = item["conversations"][0]["value"]
         response = item["conversations"][1]["value"]
 
+        tokenizer = self.processor.tokenizer
+        if tokenizer.chat_template is not None:
+            full_text = tokenizer.apply_chat_template(
+                [{"role": "user", "content": prompt}, {"role": "assistant", "content": response}],
+                tokenize=False,
+                add_generation_prompt=False,
+            )
+            prompt_text = tokenizer.apply_chat_template(
+                [{"role": "user", "content": prompt}],
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+        else:
+            full_text = prompt + response
+            prompt_text = prompt
+
         processed = self.processor(
             images=image,
-            text=prompt + response,
+            text=full_text,
         )
         input_ids = processed["input_ids"].squeeze(0)
         attention_mask = processed["attention_mask"].squeeze(0)
         pixel_values = processed["pixel_values"].squeeze(0)
 
-        processed_prompt = self.processor(
-            text=prompt,
-        )
+        processed_prompt = self.processor(text=prompt_text)
         num_prompt_tokens = processed_prompt["input_ids"].shape[-1]
         labels = input_ids.clone()
         labels[:num_prompt_tokens] = -100


### PR DESCRIPTION
apply the chat template for phase 1 training

now that we're using instruction tuned LLMs we should do this as per @Rahul007007 's recommendation


run is in progress, but it looks roughly the same
<img width="1366" height="668" alt="Screenshot 2026-03-16 at 8 55 57 PM" src="https://github.com/user-attachments/assets/d88aa9e7-12cd-4fb3-bad1-34c3e3fa123a" />
