### PR TITLE
Refactor image_hidden_states handling and clarify image_grid_hws

### DIFF
--- a/models/tiny_aya_vision.py
+++ b/models/tiny_aya_vision.py
@@ -217,7 +217,7 @@ class TinyAyaVisionForConditionalGeneration(nn.Module, GenerationMixin):
             past_key_values=outputs.past_key_values,
             hidden_states=getattr(outputs, "hidden_states", None),
             attentions=getattr(outputs, "attentions", None),
-            image_hidden_states=image_features if not isinstance(image_features, list) else None,
+            image_hidden_states=torch.cat(image_features, dim=0) if isinstance(image_features, list) else image_features,
         )
 
     def prepare_inputs_for_generation(

--- a/pipeline/train_alignment.py
+++ b/pipeline/train_alignment.py
@@ -83,10 +83,12 @@ def train(
                 ce_loss = outputs.loss / training_config.grad_acc_steps
 
                 token_embeddings = model.language_model.get_input_embeddings().weight # (vocab size, D)
-                image_hidden_states = outputs.image_hidden_states # (B, V, D)
+                image_hidden_states = outputs.image_hidden_states # (B, V, D) or (total_tokens, D)
 
-                align_reg_loss = (token_embeddings.mean(dim=0) - image_hidden_states.mean(dim=(0, 1))).square().sum() \
-                                + (token_embeddings.std(dim=0) - image_hidden_states.std(dim=(0, 1))).square().sum()
+                # Flatten to 2-D for both SigLIP (B, V, D) and MoonViT (total_tokens, D)
+                ihs = image_hidden_states.reshape(-1, image_hidden_states.shape[-1])
+                align_reg_loss = (token_embeddings.mean(dim=0) - ihs.mean(dim=0)).square().sum() \
+                                + (token_embeddings.std(dim=0) - ihs.std(dim=0)).square().sum()
                 align_reg_loss /= training_config.grad_acc_steps
                 
             loss = ce_loss + training_config.embed_align_reg * align_reg_loss

--- a/src/processing.py
+++ b/src/processing.py
@@ -54,8 +54,8 @@ class TinyAyaVisionProcessor:
                     "image_grid_hws is required for MoonViT to determine token counts. "
                     "Run the image processor first and pass image_grid_hws here."
                 )
-            # image_grid_hws: (B, 2) — [H, W] tile grid per image; total visual tokens = H * W * tokens_per_tile
-            return (image_grid_hws[:, 0] * image_grid_hws[:, 1] * self.config.tokens_per_tile).tolist()
+            # image_grid_hws: (B, 2) — [H, W] grid per image; H * W = total visual tokens
+            return (image_grid_hws[:, 0] * image_grid_hws[:, 1]).tolist()
         else:
             return [self.config.num_tokens_after_shuffle] * n_images
 


### PR DESCRIPTION
Revert back of _tokens_per_image not using tokens_per_tile. It didn't work and have shape mismatch. Will retrace the bug later.

Refactor the image_hidden_states

Command used:
` MODAL_GPU=A100-80GB PYTORCH_ALLOC_CONF=expandable_segments:True modal run --detach scripts/m
odal_train_alignment.py --vision moonvit `