### PR TITLE
lm-eval + global mgsm

### DIFF
--- a/evaluation/tasks/global_mgsm/_default_yaml
+++ b/evaluation/tasks/global_mgsm/_default_yaml
@@ -1,0 +1,32 @@
+tag: global_mgsm_direct
+dataset_path: CohereLabs/global-mgsm
+output_type: generate_until
+test_split: test
+doc_to_text: "{{instruction}}\n\n{{question}}"
+doc_to_target: "{{answer}}"
+target_delimiter: ""
+generation_kwargs:
+  until:
+    - "\n\n"
+    - "\n"
+  do_sample: false
+  temperature: 0.0
+filter_list:
+  - name: remove_whitespace
+    filter:
+      - function: remove_whitespace
+      - function: take_first
+  - name: flexible-extract
+    filter:
+      - function: regex
+        group_select: -1
+        regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+      - function: take_first
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+metadata:
+  version: 1.0

--- a/evaluation/tasks/global_mgsm/global_mgsm.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm.yaml
@@ -1,0 +1,91 @@
+group: global_mgsm
+group_alias: Global MGSM (41 languages)
+task:
+  - task: global_mgsm_direct_am
+    task_alias: am
+  - task: global_mgsm_direct_ar
+    task_alias: ar
+  - task: global_mgsm_direct_bn
+    task_alias: bn
+  - task: global_mgsm_direct_ca
+    task_alias: ca
+  - task: global_mgsm_direct_cs
+    task_alias: cs
+  - task: global_mgsm_direct_cy
+    task_alias: cy
+  - task: global_mgsm_direct_de
+    task_alias: de
+  - task: global_mgsm_direct_el
+    task_alias: el
+  - task: global_mgsm_direct_en
+    task_alias: en
+  - task: global_mgsm_direct_es
+    task_alias: es
+  - task: global_mgsm_direct_eu
+    task_alias: eu
+  - task: global_mgsm_direct_fr
+    task_alias: fr
+  - task: global_mgsm_direct_gl
+    task_alias: gl
+  - task: global_mgsm_direct_gu
+    task_alias: gu
+  - task: global_mgsm_direct_ha
+    task_alias: ha
+  - task: global_mgsm_direct_hu
+    task_alias: hu
+  - task: global_mgsm_direct_ja
+    task_alias: ja
+  - task: global_mgsm_direct_km
+    task_alias: km
+  - task: global_mgsm_direct_kn
+    task_alias: kn
+  - task: global_mgsm_direct_ko
+    task_alias: ko
+  - task: global_mgsm_direct_ky
+    task_alias: ky
+  - task: global_mgsm_direct_lg
+    task_alias: lg
+  - task: global_mgsm_direct_my
+    task_alias: my
+  - task: global_mgsm_direct_ne
+    task_alias: ne
+  - task: global_mgsm_direct_ru
+    task_alias: ru
+  - task: global_mgsm_direct_si
+    task_alias: si
+  - task: global_mgsm_direct_sn
+    task_alias: sn
+  - task: global_mgsm_direct_sr
+    task_alias: sr
+  - task: global_mgsm_direct_st
+    task_alias: st
+  - task: global_mgsm_direct_sw
+    task_alias: sw
+  - task: global_mgsm_direct_ta
+    task_alias: ta
+  - task: global_mgsm_direct_te
+    task_alias: te
+  - task: global_mgsm_direct_th
+    task_alias: th
+  - task: global_mgsm_direct_ur
+    task_alias: ur
+  - task: global_mgsm_direct_uz
+    task_alias: uz
+  - task: global_mgsm_direct_vi
+    task_alias: vi
+  - task: global_mgsm_direct_wo
+    task_alias: wo
+  - task: global_mgsm_direct_xh
+    task_alias: xh
+  - task: global_mgsm_direct_yo
+    task_alias: yo
+  - task: global_mgsm_direct_zh
+    task_alias: zh
+  - task: global_mgsm_direct_zu
+    task_alias: zu
+aggregate_metric_list:
+  - metric: exact_match
+    aggregation: mean
+    weight_by_size: true
+metadata:
+  version: 2.0

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_am.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_am.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_am
+dataset_name: am
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_ar.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_ar.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_ar
+dataset_name: ar
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_bn.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_bn.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_bn
+dataset_name: bn
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_ca.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_ca.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_ca
+dataset_name: ca
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_cs.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_cs.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_cs
+dataset_name: cs
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_cy.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_cy.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_cy
+dataset_name: cy
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_de.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_de.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_de
+dataset_name: de
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_el.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_el.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_el
+dataset_name: el
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_en.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_en.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_en
+dataset_name: en
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_es.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_es.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_es
+dataset_name: es
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_eu.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_eu.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_eu
+dataset_name: eu
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_fr.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_fr.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_fr
+dataset_name: fr
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_gl.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_gl.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_gl
+dataset_name: gl
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_gu.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_gu.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_gu
+dataset_name: gu
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_ha.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_ha.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_ha
+dataset_name: ha
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_hu.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_hu.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_hu
+dataset_name: hu
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_ja.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_ja.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_ja
+dataset_name: ja
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_km.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_km.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_km
+dataset_name: km
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_kn.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_kn.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_kn
+dataset_name: kn
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_ko.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_ko.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_ko
+dataset_name: ko
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_ky.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_ky.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_ky
+dataset_name: ky
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_lg.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_lg.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_lg
+dataset_name: lg
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_my.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_my.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_my
+dataset_name: my
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_ne.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_ne.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_ne
+dataset_name: ne
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_ru.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_ru.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_ru
+dataset_name: ru
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_si.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_si.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_si
+dataset_name: si
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_sn.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_sn.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_sn
+dataset_name: sn
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_sr.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_sr.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_sr
+dataset_name: sr
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_st.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_st.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_st
+dataset_name: st
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_sw.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_sw.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_sw
+dataset_name: sw
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_ta.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_ta.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_ta
+dataset_name: ta
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_te.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_te.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_te
+dataset_name: te
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_th.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_th.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_th
+dataset_name: th
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_ur.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_ur.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_ur
+dataset_name: ur
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_uz.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_uz.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_uz
+dataset_name: uz
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_vi.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_vi.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_vi
+dataset_name: vi
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_wo.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_wo.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_wo
+dataset_name: wo
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_xh.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_xh.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_xh
+dataset_name: xh
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_yo.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_yo.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_yo
+dataset_name: yo
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_zh.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_zh.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_zh
+dataset_name: zh
+include: _default_yaml

--- a/evaluation/tasks/global_mgsm/global_mgsm_direct_zu.yaml
+++ b/evaluation/tasks/global_mgsm/global_mgsm_direct_zu.yaml
@@ -1,0 +1,3 @@
+task: global_mgsm_direct_zu
+dataset_name: zu
+include: _default_yaml

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,8 +1,12 @@
 """Tests for the evaluation harness setup."""
 
+import yaml
 import pytest
+from pathlib import Path
 
 from evaluation.m_arena_hard import LANGUAGES, load_arena_hard
+
+TASKS_DIR = Path(__file__).parent.parent / "evaluation" / "tasks"
 
 
 class TestMArenaHard:
@@ -135,3 +139,59 @@ class TestXMMMUTask:
         results = ["B"]
         score = xmmmu_process_results(doc, results)
         assert score["exact_match"] == 1.0
+
+
+MGSM_LANGUAGES = [
+    "am", "ar", "bn", "ca", "cs", "cy", "de", "el", "en", "es",
+    "eu", "fr", "gl", "gu", "ha", "hu", "ja", "km", "kn", "ko",
+    "ky", "lg", "my", "ne", "ru", "si", "sn", "sr", "st", "sw",
+    "ta", "te", "th", "ur", "uz", "vi", "wo", "xh", "yo", "zh", "zu",
+]
+
+
+class TestGlobalMGSMTask:
+    """Tests for the GlobalMGSM group task configuration."""
+
+    @pytest.fixture
+    def config(self):
+        yaml_path = TASKS_DIR / "global_mgsm" / "global_mgsm.yaml"
+        return yaml.safe_load(yaml_path.read_text())
+
+    def test_yaml_loads(self, config):
+        """GlobalMGSM group task YAML loads without errors."""
+        assert config is not None
+
+    def test_group_name(self, config):
+        """Group is named global_mgsm."""
+        assert config["group"] == "global_mgsm"
+
+    def test_all_41_languages_included(self, config):
+        """All 41 languages are present as subtasks."""
+        task_names = [t["task"] for t in config["task"]]
+        for lang in MGSM_LANGUAGES:
+            assert f"global_mgsm_direct_{lang}" in task_names
+
+    def test_language_count(self, config):
+        """Exactly 41 language subtasks are defined."""
+        assert len(config["task"]) == len(MGSM_LANGUAGES)
+
+    def test_aggregate_metric(self, config):
+        """exact_match is the aggregate metric."""
+        metrics = [m["metric"] for m in config["aggregate_metric_list"]]
+        assert "exact_match" in metrics
+
+    def test_per_language_yaml_exists(self):
+        """Each language has its own task YAML file."""
+        for lang in MGSM_LANGUAGES:
+            yaml_path = TASKS_DIR / "global_mgsm" / f"global_mgsm_direct_{lang}.yaml"
+            assert yaml_path.exists(), f"Missing YAML for {lang}"
+            cfg = yaml.safe_load(yaml_path.read_text())
+            assert cfg["task"] == f"global_mgsm_direct_{lang}"
+            assert cfg["dataset_name"] == lang
+
+    def test_default_yaml_exists(self):
+        """Base _default_yaml template exists and has correct dataset_path."""
+        default_path = TASKS_DIR / "global_mgsm" / "_default_yaml"
+        assert default_path.exists()
+        cfg = yaml.safe_load(default_path.read_text())
+        assert cfg["dataset_path"] == "CohereLabs/global-mgsm"


### PR DESCRIPTION
we can use this for model merge sweeping to evaluate regression

`modal run scripts/modal_eval.py --task global_mgsm` to run all evals

`modal run scripts/modal_eval.py --task global_mgsm_direct_<LANGUAGE_ID>` to run for a single language

it's a bit unsightly but we have a separate short config file per language (required by lm-eval)