### PR TITLE
make tinyayavision hf compatible

### DIFF
--- a/config/model_config.py
+++ b/config/model_config.py
@@ -1,65 +1,81 @@
 from __future__ import annotations
 
-import dataclasses
-from dataclasses import dataclass
+import inspect
 from pathlib import Path
 
 import yaml
+from transformers import PretrainedConfig
 
 
-@dataclass
-class TinyAyaVisionConfig:
+class TinyAyaVisionConfig(PretrainedConfig):
     """Central configuration for the Tiny Aya Vision model."""
 
-    # Vision encoder type: "siglip" | "moonvit"
-    vision_encoder_type: str = "siglip"
+    model_type = "tiny_aya_vision"
 
-    # Vision encoder (SigLIP2-so400m-patch14-384)
-    vision_model_name: str = "google/siglip2-so400m-patch14-384"
-    vision_hidden_size: int = 1152
-    image_size: int = 384
-    patch_size: int = 14
-    vision_grid_size: int = 27  # 384 // 14
-    num_vision_tokens: int = 729  # 27 * 27
-    trust_remote_code: bool = False
-
-    # Connector type: "pixel_shuffle" | "linear_mlp"
-    connector_type: str = "pixel_shuffle"
-
-    # Pixel Shuffle (4x token compression) — SigLIP only
-    downsample_factor: int = 2
-    padded_grid_size: int = 28  # ceil_to_even(27)
-    num_tokens_after_shuffle: int = 196  # (28 // 2) ** 2
-    pixel_shuffle_embed_dim: int = 4608  # 1152 * (2 ** 2)
-
-    # MoonViT — tokens per tile (output structure: list of (N_tiles, tokens_per_tile, D))
-    tokens_per_tile: int = 4
-    # MoonViT — max patches fed to the encoder (caps visual tokens per image)
-    in_token_limit: int = 1024
-
-    # Vision-language connector (2-layer MLP with SwiGLU)
-    connector_intermediate_size: int = 2048  # matches LLM hidden_size
-    adapter_layer_norm_eps: float = 1e-6
-    post_projector_rms_norm: bool = False
-
-    # LLM backbone
-    llm_model_name: str = "CohereLabs/tiny-aya-base"
-    llm_hidden_size: int = 2048
-    llm_vocab_size: int = 262144
-    num_llm_layers: int = 36  # Cohere2: 36 transformer layers
-
-    # Special tokens
-    image_token: str = "<image>"
-
-    # Inference defaults
-    torch_dtype: str = "bfloat16"
-
-    # Vision feature extraction
-    vision_feature_layer: int = -1
-    # "full" = all patches, "default" = crop CLS
-    vision_feature_select_strategy: str = "full"
-
-    cache_dir: str = ""  # adjust this path as needed
+    def __init__(
+        self,
+        vision_encoder_type: str = "siglip",
+        vision_model_name: str = "google/siglip2-so400m-patch14-384",
+        vision_hidden_size: int = 1152,
+        image_size: int = 384,
+        patch_size: int = 14,
+        vision_grid_size: int = 27,
+        num_vision_tokens: int = 729,
+        trust_remote_code: bool = False,
+        connector_type: str = "pixel_shuffle",
+        downsample_factor: int = 2,
+        padded_grid_size: int = 28,
+        num_tokens_after_shuffle: int = 196,
+        pixel_shuffle_embed_dim: int = 4608,
+        tokens_per_tile: int = 4,
+        in_token_limit: int = 1024,
+        connector_intermediate_size: int = 2048,
+        adapter_layer_norm_eps: float = 1e-6,
+        post_projector_rms_norm: bool = False,
+        llm_model_name: str = "CohereLabs/tiny-aya-base",
+        llm_hidden_size: int = 2048,
+        llm_vocab_size: int = 262144,
+        num_llm_layers: int = 36,
+        image_token: str = "<image>",
+        image_token_id: int | None = None,
+        torch_dtype: str = "bfloat16",
+        vision_feature_layer: int = -1,
+        vision_feature_select_strategy: str = "full",
+        cache_dir: str | None = None,
+        text_config: dict | None = None,
+        vision_tower_config: dict | None = None,
+        **kwargs,
+    ):
+        self.vision_encoder_type = vision_encoder_type
+        self.vision_model_name = vision_model_name
+        self.vision_hidden_size = vision_hidden_size
+        self.image_size = image_size
+        self.patch_size = patch_size
+        self.vision_grid_size = vision_grid_size
+        self.num_vision_tokens = num_vision_tokens
+        self.trust_remote_code = trust_remote_code
+        self.connector_type = connector_type
+        self.downsample_factor = downsample_factor
+        self.padded_grid_size = padded_grid_size
+        self.num_tokens_after_shuffle = num_tokens_after_shuffle
+        self.pixel_shuffle_embed_dim = pixel_shuffle_embed_dim
+        self.tokens_per_tile = tokens_per_tile
+        self.in_token_limit = in_token_limit
+        self.connector_intermediate_size = connector_intermediate_size
+        self.adapter_layer_norm_eps = adapter_layer_norm_eps
+        self.post_projector_rms_norm = post_projector_rms_norm
+        self.llm_model_name = llm_model_name
+        self.llm_hidden_size = llm_hidden_size
+        self.llm_vocab_size = llm_vocab_size
+        self.num_llm_layers = num_llm_layers
+        self.image_token = image_token
+        self.image_token_id = image_token_id
+        self.vision_feature_layer = vision_feature_layer
+        self.vision_feature_select_strategy = vision_feature_select_strategy
+        self.cache_dir = cache_dir
+        self.text_config = text_config
+        self.vision_tower_config = vision_tower_config
+        super().__init__(torch_dtype=torch_dtype, **kwargs)
 
     @classmethod
     def for_base(cls) -> TinyAyaVisionConfig:
@@ -94,7 +110,8 @@ class TinyAyaVisionConfig:
         with open(yaml_path) as f:
             overrides = yaml.safe_load(f)
 
-        valid_fields = {f.name for f in dataclasses.fields(cls)}
+        sig = inspect.signature(cls.__init__)
+        valid_fields = set(sig.parameters.keys()) - {"self", "kwargs"}
         filtered = {k: v for k, v in overrides.items() if k in valid_fields}
 
         llm_names = {

--- a/evaluation/run_eval.py
+++ b/evaluation/run_eval.py
@@ -2,18 +2,16 @@
 uv run python evaluation/run_eval.py
 
 Args:
-    [--task]: cvqa_blind, ...
-    [--backend]: vllm | hf
+    [--task]: cvqa, cvqa_blind, xmmmu, ...
+    [--backend]: vllm | hf | hf-multimodal
     [--batch-size]: auto | 1 (vllm | hf)
     [--limit]: int  (num samples for quick tests)
     [--output-dir]: str
-    [--model-name]: str
+    [--model-name]: str (HF repo id OR local path to save_pretrained output)
 
 """
 
 import argparse
-import subprocess
-import os
 import logging
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -23,8 +21,8 @@ def main():
     parser = argparse.ArgumentParser(description="lm-eval runner for Tiny Aya Vision benchmarks.")
     parser.add_argument("--task", type=str, required=True)
     parser.add_argument("--model-name", type=str, required=True)
-    parser.add_argument("--backend", type=str, default="vllm", choices=["vllm", "hf"])
-    parser.add_argument("--batch-size", type=str, default="auto")
+    parser.add_argument("--backend", type=str, default="hf-multimodal", choices=["vllm", "hf", "hf-multimodal"])
+    parser.add_argument("--batch-size", type=str, default="1")
     parser.add_argument("--limit", type=int, default=None)
     parser.add_argument("--output-dir", type=str, default="evaluation/results")
     parser.add_argument("--log-samples", action="store_true", help="Log per-question results")
@@ -36,34 +34,44 @@ def main():
     logger.info(f"Model: {args.model_name}")
     logger.info(f"=========================================")
 
+    # Register TinyAyaVision with HuggingFace Auto classes so lm-eval can
+    # load it via AutoModelForCausalLM.from_pretrained / AutoConfig.
+    import models  # noqa: F401 — triggers Auto class registration
+
+    import lm_eval
+
     model_args = f"pretrained={args.model_name},dtype=bfloat16,trust_remote_code=True"
     if args.backend == "vllm":
         model_args += ",tensor_parallel_size=1"
-    
-    cmd = [
-        "lm_eval",
-        "--model", args.backend,
-        "--model_args", model_args,
-        "--task", args.task,
-        "--batch_size", args.batch_size,
-        "--include_path", "evaluation/tasks",
-        "--output_path", args.output_dir
-    ]
+
+    eval_kwargs = dict(
+        model=args.backend,
+        model_args=model_args,
+        tasks=[args.task],
+        batch_size=args.batch_size,
+        task_manager=lm_eval.tasks.TaskManager(include_path="evaluation/tasks"),
+        log_samples=args.log_samples,
+    )
 
     if args.limit is not None:
-        cmd.extend(["--limit", str(args.limit)])
-    
-    if args.log_samples:
-        cmd.append("--log_samples")
-    
+        eval_kwargs["limit"] = args.limit
+
     if args.apply_chat_template:
-        cmd.append("--apply_chat_template")
-    
-    try:
-        subprocess.run(cmd, check=True)
-    except subprocess.CalledProcessError as e:
-        logger.error(f"Evaluation failed with exit code: {e.returncode}")
-        exit(e.returncode)
+        eval_kwargs["apply_chat_template"] = True
+
+    results = lm_eval.simple_evaluate(**eval_kwargs)
+
+    from lm_eval.utils import make_table
+    logger.info(make_table(results))
+
+    if args.output_dir:
+        import json
+        from pathlib import Path
+        output_path = Path(args.output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+        with open(output_path / f"{args.task}_results.json", "w") as f:
+            json.dump(results.get("results", {}), f, indent=2)
+        logger.info(f"Results saved to {output_path / f'{args.task}_results.json'}")
 
 
 if __name__ == "__main__":

--- a/evaluation/utils.py
+++ b/evaluation/utils.py
@@ -62,6 +62,7 @@ def load_model_config_from_hub(repo: str = HF_REPO) -> TinyAyaVisionConfig:
 
 
 def load_model(device: torch.device, repo: str = HF_REPO):
+    """Load model + processor from a Hub repo with legacy connector.pt format."""
     model_config = load_model_config_from_hub(repo)
     processor = TinyAyaVisionProcessor(config=model_config)
     model = TinyAyaVisionForConditionalGeneration(config=model_config)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,6 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from transformers import AutoConfig, AutoModel, AutoModelForCausalLM
+
+from config.model_config import TinyAyaVisionConfig
 from .tiny_aya_vision import TinyAyaVisionForConditionalGeneration, TinyAyaVisionOutput
 
+if TYPE_CHECKING:
+    from src.processing import TinyAyaVisionProcessor
+
+AutoConfig.register("tiny_aya_vision", TinyAyaVisionConfig)
+AutoModel.register(TinyAyaVisionConfig, TinyAyaVisionForConditionalGeneration)
+AutoModelForCausalLM.register(TinyAyaVisionConfig, TinyAyaVisionForConditionalGeneration)
+
+
+def save_for_inference(
+    model: TinyAyaVisionForConditionalGeneration,
+    processor: TinyAyaVisionProcessor,
+    output_dir: str | Path,
+) -> None:
+    """Save the full model in HuggingFace-compatible format.
+
+    After calling this, the model can be loaded with:
+        import models  # registers Auto classes
+        model = AutoModelForCausalLM.from_pretrained(output_dir, trust_remote_code=True)
+
+    Args:
+        model: Trained TinyAyaVision model.
+        processor: The processor (tokenizer + image processor are saved).
+        output_dir: Directory to write config.json + model weights.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    model.save_pretrained(output_dir)
+    processor.tokenizer.save_pretrained(output_dir)
+    processor.image_processor.save_pretrained(output_dir)
+
+
 __all__ = [
+    "TinyAyaVisionConfig",
     "TinyAyaVisionForConditionalGeneration",
     "TinyAyaVisionOutput",
+    "save_for_inference",
 ]

--- a/models/tiny_aya_vision.py
+++ b/models/tiny_aya_vision.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
 
 import torch
-import torch.nn as nn
-from transformers import AutoModelForCausalLM, GenerationMixin
+from transformers import AutoModelForCausalLM, PreTrainedModel
 from transformers.modeling_outputs import ModelOutput
 
 from config.model_config import TinyAyaVisionConfig
@@ -22,7 +21,7 @@ class TinyAyaVisionOutput(ModelOutput):
     image_hidden_states: torch.FloatTensor | None = None
 
 
-class TinyAyaVisionForConditionalGeneration(nn.Module, GenerationMixin):
+class TinyAyaVisionForConditionalGeneration(PreTrainedModel):
     """Tiny Aya Vision: multilingual VLM connecting a vision encoder to Tiny Aya Base.
 
     Architecture:
@@ -33,35 +32,41 @@ class TinyAyaVisionForConditionalGeneration(nn.Module, GenerationMixin):
     projected vision features, then runs the combined sequence through the LLM.
     """
 
+    config_class = TinyAyaVisionConfig
     main_input_name = "input_ids"
-    _is_stateful = False  # required by GenerationMixin._supports_default_dynamic_cache
+    _supports_flash_attn_2 = False
+    _no_split_modules = ["SigLIPVisionEncoder", "MoonViTVisionEncoder"]
+    _tied_weights_keys = ["language_model.lm_head.weight"]
 
     def __init__(self, config: TinyAyaVisionConfig):
-        super().__init__()
-        self.vlm_config = config
+        super().__init__(config)
 
-        # Vision encoder (frozen) — selected by config.vision_encoder_type
         self.vision_encoder = create_vision_encoder(config)
+        if config.vision_tower_config is None:
+            config.vision_tower_config = self.vision_encoder.vision_model.config.to_dict()
 
-        # Vision-language connector (trainable), cast to configured dtype so
-        # it matches the bfloat16 outputs from the frozen vision encoder.
-        self.multi_modal_projector = create_projector(config).to(
-            getattr(torch, config.torch_dtype)
-        )
+        self.multi_modal_projector = create_projector(config).to(config.torch_dtype)
 
-        # Language model
-        self.language_model = AutoModelForCausalLM.from_pretrained(
-            config.llm_model_name,
-            torch_dtype=getattr(torch, config.torch_dtype),
-            cache_dir=config.cache_dir,
-        )
+        if config.text_config is not None:
+            from transformers import CONFIG_MAPPING
+            text_config_cls = CONFIG_MAPPING[config.text_config["model_type"]]
+            text_cfg = text_config_cls.from_dict(config.text_config)
+            self.language_model = AutoModelForCausalLM.from_config(text_cfg)
+        else:
+            self.language_model = AutoModelForCausalLM.from_pretrained(
+                config.llm_model_name,
+                torch_dtype=config.torch_dtype,
+                cache_dir=config.cache_dir,
+            )
+            config.text_config = self.language_model.config.to_dict()
 
-        # Expose the LLM's PretrainedConfig as self.config so GenerationMixin
-        # can call self.config._get_generation_parameters() and related methods.
-        self.config = self.language_model.config
+        self.generation_config = self.language_model.generation_config
+        self._image_token_id: int | None = config.image_token_id
 
-        # Store the image token id (set during tokenizer setup)
-        self._image_token_id: int | None = None
+        self.post_init()
+
+    def _init_weights(self, module):
+        pass
 
     @property
     def image_token_id(self) -> int:
@@ -71,36 +76,32 @@ class TinyAyaVisionForConditionalGeneration(nn.Module, GenerationMixin):
             )
         return self._image_token_id
 
-    @property
-    def device(self) -> torch.device:
-        return next(self.language_model.parameters()).device
-
-    @property
-    def generation_config(self):
-        return self.language_model.generation_config
-
-    @generation_config.setter
-    def generation_config(self, value):
-        self.language_model.generation_config = value
-
     def setup_tokenizer(self, tokenizer) -> None:
         """Add <image> special token to tokenizer and resize embeddings.
 
         Must be called after initialization and before forward/generate.
         """
         num_added = tokenizer.add_special_tokens(
-            {"additional_special_tokens": [self.vlm_config.image_token]}
+            {"additional_special_tokens": [self.config.image_token]}
         )
-        self._image_token_id = tokenizer.convert_tokens_to_ids(self.vlm_config.image_token)
+        self._image_token_id = tokenizer.convert_tokens_to_ids(self.config.image_token)
+        self.config.image_token_id = self._image_token_id
 
         if num_added > 0:
             self.language_model.resize_token_embeddings(len(tokenizer))
+            self.config.text_config = self.language_model.config.to_dict()
 
     def get_input_embeddings(self):
         return self.language_model.get_input_embeddings()
 
     def set_input_embeddings(self, value):
         self.language_model.set_input_embeddings(value)
+
+    def get_output_embeddings(self):
+        return self.language_model.get_output_embeddings()
+
+    def set_output_embeddings(self, new_embeddings):
+        self.language_model.set_output_embeddings(new_embeddings)
 
     def get_image_features(
         self,
@@ -118,14 +119,12 @@ class TinyAyaVisionForConditionalGeneration(nn.Module, GenerationMixin):
             MoonViT: list of (N_tiles_i * tokens_per_tile, llm_hidden_size) tensors,
                      one per image.
         """
-        if self.vlm_config.vision_encoder_type == "moonvit":
-            # Returns list of (N_tiles_i, tokens_per_tile, D) tensors
+        if self.config.vision_encoder_type == "moonvit":
             raw_features = self.vision_encoder(pixel_values, image_grid_hws=image_grid_hws)
             projected = []
             for feat in raw_features:
-                # (N_tiles, tokens_per_tile, D) -> (N_tiles * tokens_per_tile, D)
                 feat = feat.view(-1, feat.shape[-1])
-                proj = self.multi_modal_projector(feat)  # (T, llm_hidden_size)
+                proj = self.multi_modal_projector(feat)
                 projected.append(proj)
             return projected
         else:
@@ -147,10 +146,8 @@ class TinyAyaVisionForConditionalGeneration(nn.Module, GenerationMixin):
         special_image_mask = input_ids == self.image_token_id
 
         if isinstance(image_features, list):
-            # MoonViT: concatenate all per-image features, scatter in sequence order
-            flat_features = torch.cat(image_features, dim=0)  # (sum(T_i), D)
+            flat_features = torch.cat(image_features, dim=0)
         else:
-            # SigLIP: flatten (B, T, D) -> (B*T, D)
             flat_features = image_features.reshape(-1, image_features.shape[-1])
 
         n_image_tokens = special_image_mask.sum().item()
@@ -181,19 +178,9 @@ class TinyAyaVisionForConditionalGeneration(nn.Module, GenerationMixin):
         cache_position: torch.LongTensor | None = None,
         **kwargs,
     ) -> TinyAyaVisionOutput:
-        """Forward pass for the VLM.
-
-        For multimodal input: pass both input_ids (with <image> placeholders)
-        and pixel_values. The <image> tokens are replaced with projected vision
-        features before being passed to the LLM.
-
-        For MoonViT: also pass image_grid_hws from the processor output.
-        For text-only input: pass input_ids without pixel_values.
-        """
         if inputs_embeds is None:
             inputs_embeds = self.get_input_embeddings()(input_ids)
 
-        # Merge image features into the text embedding sequence
         image_features = None
         if pixel_values is not None:
             image_features = self.get_image_features(pixel_values, image_grid_hws)
@@ -246,7 +233,6 @@ class TinyAyaVisionForConditionalGeneration(nn.Module, GenerationMixin):
             **kwargs,
         )
 
-        # Only pass pixel_values on the first iteration (no cache yet)
         is_first = past_key_values is None or (
             cache_position is not None and cache_position[0] == 0
         )

--- a/pipeline/train_alignment.py
+++ b/pipeline/train_alignment.py
@@ -179,7 +179,7 @@ def run(cfg: DictConfig):
         with open(config_path, "w") as f:
             json.dump({
                 "training_config": asdict(training_config),
-                "model_config": asdict(model_config),
+                "model_config": model_config.to_dict(),
             }, f, indent=2)
 
     wandb.init(
@@ -189,7 +189,7 @@ def run(cfg: DictConfig):
         name=run_id,
         id=run_id.replace("-", ""),
         resume="allow",
-        config={**asdict(training_config), **asdict(model_config)},
+        config={**asdict(training_config), **model_config.to_dict()},
     )
 
     model = TinyAyaVisionForConditionalGeneration(

--- a/pipeline/train_instruct.py
+++ b/pipeline/train_instruct.py
@@ -383,7 +383,7 @@ def main(
         with open(config_path, "w") as f:
             json.dump({
                 "training_config": asdict(training_config),
-                "model_config": asdict(model_config),
+                "model_config": model_config.to_dict(),
                 "lora_config": asdict(lora_config),
             }, f, indent=2)
 

--- a/src/vision_encoders/moonvit.py
+++ b/src/vision_encoders/moonvit.py
@@ -1,5 +1,5 @@
 import torch
-from transformers import AutoModel
+from transformers import AutoConfig, AutoModel
 
 from config.model_config import TinyAyaVisionConfig
 from src.vision_encoders.base import BaseVisionEncoder
@@ -22,11 +22,20 @@ class MoonViTVisionEncoder(BaseVisionEncoder):
     def __init__(self, config: TinyAyaVisionConfig):
         super().__init__()
         self.config = config
-        self.vision_model = AutoModel.from_pretrained(
-            config.vision_model_name,
-            torch_dtype=getattr(torch, config.torch_dtype),
-            trust_remote_code=True,
-        )
+        if config.vision_tower_config is not None:
+            # Downloads only the config JSON + model code (~KB), not weights (~400MB).
+            vision_cfg = AutoConfig.from_pretrained(
+                config.vision_model_name, trust_remote_code=True,
+            )
+            self.vision_model = AutoModel.from_config(
+                vision_cfg, trust_remote_code=True,
+            )
+        else:
+            self.vision_model = AutoModel.from_pretrained(
+                config.vision_model_name,
+                torch_dtype=config.torch_dtype,
+                trust_remote_code=True,
+            )
         self.vision_model.requires_grad_(False)
 
     def forward(

--- a/src/vision_encoders/siglip.py
+++ b/src/vision_encoders/siglip.py
@@ -1,5 +1,5 @@
 import torch
-from transformers import SiglipVisionModel
+from transformers import SiglipVisionConfig, SiglipVisionModel
 
 from config.model_config import TinyAyaVisionConfig
 from src.vision_encoders.base import BaseVisionEncoder
@@ -15,10 +15,14 @@ class SigLIPVisionEncoder(BaseVisionEncoder):
     def __init__(self, config: TinyAyaVisionConfig):
         super().__init__()
         self.config = config
-        self.vision_model = SiglipVisionModel.from_pretrained(
-            config.vision_model_name,
-            torch_dtype=getattr(torch, config.torch_dtype),
-        )
+        if config.vision_tower_config is not None:
+            vision_cfg = SiglipVisionConfig(**config.vision_tower_config)
+            self.vision_model = SiglipVisionModel(vision_cfg)
+        else:
+            self.vision_model = SiglipVisionModel.from_pretrained(
+                config.vision_model_name,
+                torch_dtype=config.torch_dtype,
+            )
         self.vision_model.requires_grad_(False)
 
     def forward(self, pixel_values: torch.Tensor, **kwargs) -> torch.Tensor:


### PR DESCRIPTION
make tinyayavision hf compatible so lm-eval (and anything else that uses AutoModelForCausalLM.from_pretrained) can load it natively.

the model and config now extend PreTrainedModel / PretrainedConfig and register with HF Auto classes. submodel configs (LLM text_config, vision tower config) are embedded in the saved config.json so from_pretrained can reconstruct the full architecture from a single directory without re-downloading ~4GB of submodel weights from the Hub.

the eval runner switches from shelling out to the lm_eval CLI to calling simple_evaluate in-process, which gives us proper error tracebacks and lets us register our custom model before eval starts.


now, we can load models via `AutoModelForCausalLM.from_pretrained(...`