### PR TITLE
Resolved `lm_head.weight` Missing from Finetuned Checkpoint During Weight Merge

### DIFF
--- a/scripts/merge_weights.py
+++ b/scripts/merge_weights.py
@@ -176,6 +176,15 @@ def build_merged_vlm_state(
     ft_llm_state = extract_llm_state_dict(finetuned_vlm_state)
     non_llm_state = extract_non_llm_state_dict(finetuned_vlm_state)
 
+    tied_keys = set(original_llm_state) - set(ft_llm_state)
+    if tied_keys:
+        log.info(
+            "Excluding %d key(s) from original absent in finetuned "
+            "(weight-tied or not saved — will be restored on model load): %s",
+            len(tied_keys), sorted(tied_keys),
+        )
+        original_llm_state = {k: v for k, v in original_llm_state.items() if k not in tied_keys}
+
     log.info(
         "Merging %d LLM parameter tensors with α=%.2f …", len(original_llm_state), alpha
     )

--- a/tests/test_merge_weights.py
+++ b/tests/test_merge_weights.py
@@ -219,6 +219,20 @@ class TestBuildMergedVlmState:
                 f"Mismatch at key '{merged_key}' with α=1"
             )
 
+    def test_tied_key_in_original_only_is_silently_excluded(self):
+        """Keys in original absent from finetuned (weight-tied) must be excluded from LERP,
+        not raise and not appear in merged state."""
+        # original has lm_head.weight (as PyTorch state_dict() would return)
+        orig_llm = {"model.embed_tokens.weight": torch.randn(4, 4), "lm_head.weight": torch.randn(4, 4)}
+        # finetuned checkpoint omits lm_head.weight (HF save_pretrained omits tied keys)
+        ft_vlm = _make_vlm_state(llm_keys=["model.embed_tokens.weight"])
+
+        merged = build_merged_vlm_state(orig_llm, ft_vlm, alpha=0.5)
+
+        # lm_head.weight must NOT be in merged (it's tied, not saved separately)
+        assert f"{LLM_PREFIX}lm_head.weight" not in merged
+        # embed_tokens.weight must be present and LERP'd
+        assert f"{LLM_PREFIX}model.embed_tokens.weight" in merged
 
 # ---------------------------------------------------------------------------
 # Output file written to disk


### PR DESCRIPTION
## Summary

- `lm_head.weight` is declared as a weight-tied key in `TinyAyaVisionForConditionalGeneration._tied_weights_keys`, so HF's `save_pretrained` omits it from saved checkpoints
- When the finetuned checkpoint is loaded via raw `.safetensors` file (bypassing `AutoModel.from_pretrained`), `lm_head.weight` is absent from the finetuned state dict but present in the original (`Cohere2ForCausalLM.state_dict()` includes all tied params)
- This key-set asymmetry caused `lerp_state_dicts` to raise `ValueError` (or warn in the Kaggle notebook's patched version), and copying the unmerged original value into the saved `.pt` produced an inconsistent state

## Changes

- **`scripts/merge_weights.py`** — `build_merged_vlm_state` now strips keys from `original_llm_state` that are absent in `ft_llm_state` before calling `lerp_state_dicts`, logging at `INFO` level. These keys are weight-tied and will be restored automatically when the model is loaded via `_tied_weights_keys`
- **`tests/test_merge_weights.py`** — adds `test_tied_key_in_original_only_is_silently_excluded` to `TestBuildMergedVlmState`, covering the exact scenario where `lm_head.weight` is in the original but omitted from the finetuned checkpoint

## Behavior After Fix

- No warning or error during merge when `lm_head.weight` is absent from the finetuned checkpoint
- `lm_head.weight` is correctly absent from the merged state dict (consistent with how HF saves tied weights); it is reconstructed from `embed_tokens.weight` on model load
- Keys present in finetuned but absent from original still raise loudly in `lerp_state_dicts` — unexpected mismatches are not silently swallowed

## Test Plan

- [x] `python -m pytest tests/test_merge_weights.py -v` — all existing tests pass, new test passes
- [ ] Confirm no `WARNING` log appears for `lm_head.weight` when running against a real finetuned checkpoint on Kaggle
