### PR TITLE
Add non-blind Kaleidoscope evaluation task configs for all 18 languages

### DIFF
--- a/evaluation/tasks/kaleidoscope/_kaleidoscope_template.yaml
+++ b/evaluation/tasks/kaleidoscope/_kaleidoscope_template.yaml
@@ -1,0 +1,19 @@
+dataset_path: CohereLabs/kaleidoscope
+dataset_name: null
+test_split: train
+output_type: generate_until
+doc_to_text: !function utils.kaleidoscope_doc_to_text
+doc_to_target: !function utils.kaleidoscope_doc_to_target
+process_results: !function utils.kaleidoscope_process_results
+generation_kwargs:
+  until:
+    - "\n"
+  max_gen_toks: 16
+  temperature: 0.0
+  do_sample: false
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/evaluation/tasks/kaleidoscope/kaleidoscope.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope.yaml
@@ -1,0 +1,20 @@
+group: kaleidoscope
+task:
+  - kaleidoscope_ar
+  - kaleidoscope_bn
+  - kaleidoscope_de
+  - kaleidoscope_en
+  - kaleidoscope_es
+  - kaleidoscope_fa
+  - kaleidoscope_fr
+  - kaleidoscope_hi
+  - kaleidoscope_hr
+  - kaleidoscope_hu
+  - kaleidoscope_lt
+  - kaleidoscope_ne
+  - kaleidoscope_nl
+  - kaleidoscope_pt
+  - kaleidoscope_ru
+  - kaleidoscope_sr
+  - kaleidoscope_te
+  - kaleidoscope_uk

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_ar.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_ar.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_ar
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_ar

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_bn.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_bn.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_bn
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_bn

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_de.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_de.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_de
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_de

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_en.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_en.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_en
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_en

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_es.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_es.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_es
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_es

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_fa.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_fa.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_fa
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_fa

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_fr.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_fr.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_fr
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_fr

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_hi.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_hi.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_hi
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_hi

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_hr.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_hr.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_hr
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_hr

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_hu.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_hu.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_hu
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_hu

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_lt.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_lt.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_lt
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_lt

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_ne.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_ne.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_ne
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_ne

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_nl.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_nl.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_nl
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_nl

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_pt.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_pt.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_pt
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_pt

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_ru.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_ru.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_ru
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_ru

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_sr.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_sr.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_sr
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_sr

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_te.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_te.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_te
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_te

--- a/evaluation/tasks/kaleidoscope/kaleidoscope_uk.yaml
+++ b/evaluation/tasks/kaleidoscope/kaleidoscope_uk.yaml
@@ -1,0 +1,3 @@
+task: kaleidoscope_uk
+include: _kaleidoscope_template.yaml
+process_docs: !function utils.kaleidoscope_process_docs_uk


### PR DESCRIPTION
## Summary
- Add non-blind Kaleidoscope evaluation task for all 18 languages (ar, bn, de, en, es, fa, fr, hi, hr, hu, lt, ne, nl, pt, ru, sr, te, uk)
- Uses `generate_until` with exact_match scoring (same pattern as xmmmu)
- Adds `_kaleidoscope_template.yaml` base config and per-language YAMLs
- Adds `kaleidoscope.yaml` group task to run all languages at once

## Usage

### Run all languages
```bash
python evaluation/run_eval.py --task kaleidoscope --model-name CohereLabs/tiny-aya-global --backend hf --batch-size auto --output-dir evaluation/results/CohereLabs__tiny-aya-global --log-samples --apply-chat-template
