### PR TITLE
TPU: src/backend seam, run control, and a full alignment epoch on v6e-16

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,18 @@
+# Per-contributor state. The tooling (settings.json, hooks/, agents/,
+# commands/, skills/) is tracked; the memory files are not — PROGRESS.md is an
+# append-only machine log that would conflict on every merge, and PLAN.md /
+# memories.md are personal working state.
+PROGRESS.md
+PLAN.md
+memories.md
+# Archived PROGRESS is per-contributor too, but ship the directory itself so
+# `archive-progress` has somewhere to write on a fresh clone.
+archive/*
+!archive/.gitkeep
+
+__pycache__/
+*.pyc
+
+# Rendered diagrams. The .mmd sources are the checked-in artifact.
+orchestration/diagrams/svg/
+orchestration/diagrams/png/

--- a/.claude/MEMORY-SYSTEM.md
+++ b/.claude/MEMORY-SYSTEM.md
@@ -1,0 +1,110 @@
+# MEMORY-SYSTEM.md — how this works and how to rebuild it
+
+The external memory system gives a Claude Code session durable state across
+restarts and compaction. Six lifecycle hooks read and write four markdown files;
+skills, slash commands, and subagents are the manual interface to the same files.
+
+## Who owns what
+
+| File | Owner | Contains | Tracked in git? |
+|---|---|---|---|
+| `PLAN.md` | you + `plan-driver` | Current goal, Definition of Done, `## Tasks`, invariants | No |
+| `PROGRESS.md` | hooks (append-only) | Timestamped log of edits, commands, verify runs, session boundaries | No |
+| `VERIFY.md` | you | Fenced bash blocks the Stop hook runs as done-criteria | **Yes** |
+| `memories.md` | you + `/remember` | Operational gotchas and dated project decisions | No |
+| `settings.json` | you | Hook wiring | **Yes** |
+| `hooks/`, `agents/`, `commands/`, `skills/` | you | The system itself | **Yes** |
+
+The volatile files are gitignored via `.claude/.gitignore` — `PROGRESS.md` is a
+machine log that would conflict on every merge, and `PLAN.md`/`memories.md` are
+per-contributor working state.
+
+> **`.claude/settings.json` needs a `.gitignore` escape.** The root `.gitignore`
+> has a blanket `*.json` rule (line 11). Without `!.claude/settings.json`, a
+> `git add .claude` produces a directory with no hook wiring. That negation is in
+> place; do not remove it.
+
+## The hooks
+
+| Event | Script | Effect |
+|---|---|---|
+| SessionStart | `session_start.py` | Injects PLAN + recent PROGRESS + a VERIFY inventory line + memories as `additionalContext`. Deliberately does **not** inject `CLAUDE.md`/`AGENTS.md` — Claude Code already loads those into the cached system prompt |
+| UserPromptSubmit | `user_prompt_submit.py` | Routes `#progress` / `#plan` / `#decision` / `#verify` quick-capture prefixes to the right file |
+| PostToolUse | `post_tool_use.py` | Logs Write/Edit/MultiEdit and non-trivial Bash to PROGRESS, with repo-relative paths |
+| Stop | `stop.py` | Runs every ` ```bash ` block in VERIFY.md, logs one entry, ticks matching PLAN items |
+| PreCompact | `pre_compact.py` | Snapshots unchecked PLAN items so state survives compaction |
+| SessionEnd | `session_end.py` | Writes a "next steps" block from unchecked PLAN items |
+
+All seven files are stdlib-only, mode 644, and invoked as
+`python3 "$CLAUDE_PROJECT_DIR"/.claude/hooks/<name>.py` — no exec bit needed.
+**Every hook swallows its own exceptions**, so a broken install fails *silently*.
+That is what the `memory-system` block in VERIFY.md exists to catch. For live
+debugging, run `claude --debug`.
+
+## The ordering contract
+
+`PROGRESS.md` is newest-first. New entries are inserted directly below:
+
+```
+<!-- progress:marker -->
+```
+
+`_lib.PROGRESS_MARKER` is the single definition, imported by both
+`_lib.append_progress` and `user_prompt_submit`. If the marker is missing,
+`insert_newest_first` **re-seeds it** under the H1 rather than appending at EOF.
+
+`---` was deliberately rejected as the anchor: every skill/agent/command file in
+this system uses YAML front matter, so a `---` search eventually matches a
+closing front-matter delimiter; `---` also renders as a setext H2 or thematic
+break, gets rewritten by markdown formatters, and occurs naturally in captured
+tool output. The upstream `llm-architectures` version searched for `\n---\n` in a
+file containing zero of them, so 572 entries appended oldest-first while the
+header promised newest-first.
+
+## The Stop-hook budget
+
+15s per block × a cap of 5 blocks = 75s, inside the 90s `Stop` timeout in
+`settings.json`. All five current blocks together measure ~0.5s.
+
+Nothing slower than ~2s belongs in VERIFY.md — it runs after *every* assistant
+response. pytest (171s, and red without an HF token for the gated
+`CohereLabs/tiny-aya-*` repos) lives in `/verify-full` and CI instead.
+
+Environment overrides:
+
+| Variable | Effect |
+|---|---|
+| `MEMORY_STOP_DISABLE_VERIFY=1` | Stop hook skips verification entirely |
+| `MEMORY_STOP_BLOCK_ON_FAIL=1` | A failing block blocks the stop instead of just logging |
+| `MEMORY_ARCHIVE_DAYS` | Cutoff for `archive-progress` (default 90) |
+
+## Block IDs
+
+Each VERIFY block's first line is `# verify: <id>`. A PLAN item tagged
+`<!-- verify:<id> -->` is auto-ticked to `- [x]` when that block passes. Without
+the id the Stop hook falls back to matching the block's first 60 characters,
+which are identical across blocks — that was dead code upstream.
+
+## Rebuilding from scratch
+
+If `.claude/` is lost (a `git clean -xfd` removes the gitignored memory files):
+
+1. The tracked half restores with `git checkout .claude` — `settings.json`,
+   `hooks/`, `agents/`, `commands/`, `skills/`.
+2. Recreate `PROGRESS.md` with exactly three lines: an H1, a blank line, and
+   `<!-- progress:marker -->`. Nothing else is required; hooks append below it.
+3. Recreate `PLAN.md` with a `## Tasks` heading (the `#plan` router targets it)
+   or run `/plan <goal>` to generate one.
+4. Recreate `memories.md` with a `## Project decisions` heading (the `#decision`
+   router targets it).
+5. Run `/verify` — the `memory-system` block confirms the install.
+
+`VERIFY.md` is tracked, so it survives.
+
+## Maintenance
+
+- `/curate` runs the `memory-curator` subagent: dedupe, flag stale decisions,
+  flag PLAN items that have drifted.
+- `archive-progress` moves entries older than 90 days (or beyond 500 lines) into
+  `archive/PROGRESS-YYYY-Qn.md`. The upstream log reached 2,784 lines before
+  anyone ran it — check `wc -l .claude/PROGRESS.md` occasionally.

--- a/.claude/VERIFY.md
+++ b/.claude/VERIFY.md
@@ -1,0 +1,326 @@
+# VERIFY.md — done-criteria
+
+Every fenced ` ```bash ` block below is executed by the **Stop hook after each
+assistant response**, from the repo root, via `bash -eo pipefail -c`, with a
+12-second per-block timeout and a cap of 6 blocks (72s against the 90s hook
+timeout).
+
+Rules for adding a block:
+
+- First line must be `# verify: <stable-id>`. The id ties the block to a
+  `<!-- verify:<id> -->` tag in PLAN.md, which the Stop hook auto-ticks.
+- Side-effect free. Must leave the working tree byte-identical.
+- Must finish in well under 2s on a warm cache. Anything slower belongs in
+  `/verify-full` or CI.
+- Must pass on a clean tree *today*. A permanently-red check trains everyone to
+  ignore this file.
+- Guard optional tooling with a `skip:` message and `exit 0`.
+
+Blocks tagged ` ```sh ` are documentation only — the Stop hook does not run them.
+
+---
+
+## 1. Lint is clean
+
+`per-file-ignores` in `pyproject.toml` ratifies E402 in `scripts/modal_*.py`
+(Modal requires imports inside/after image definitions). Everything else must be
+zero.
+
+```bash
+# verify: ruff-full
+cd "${CLAUDE_PROJECT_DIR:-$PWD}" || exit 1
+{ command -v uv >/dev/null 2>&1 && [ -d .venv ]; } || { echo "skip: no uv/.venv"; exit 0; }
+uv run --no-sync ruff check . --quiet && echo "ruff-full-ok"
+```
+
+## 2. Root shell entrypoints parse
+
+`eval_cvqa.sh`, `eval_cvqa_merged.sh`, `eval_cvqa_qwen3_vl_4b.sh`,
+`merge_weights.sh` are hand-edited between eval runs, and a syntax error there is
+only discovered minutes into a Modal job.
+
+`scripts/tpu/*.sh` matters more than the root scripts: a syntax error there is only
+discovered 10-30 minutes into a spot acquisition, on a slice that is already billing.
+The `[ -e ]` guard keeps unmatched globs from failing before those directories exist.
+
+```bash
+# verify: shell-syntax
+cd "${CLAUDE_PROJECT_DIR:-$PWD}" || exit 1
+n=0
+for f in ./*.sh scripts/tpu/*.sh scripts/ci/*.sh .claude/orchestration/diagrams/*.sh; do
+  [ -e "$f" ] || continue          # unmatched globs stay literal; skip them
+  bash -n "$f" || exit 1
+  n=$((n+1))
+done
+echo "shell-syntax-ok ($n files)"
+```
+
+## 3. Config contracts hold
+
+Three things at once: every YAML under `config/` parses; the SigLIP pixel-shuffle
+token arithmetic is internally consistent (a wrong `num_tokens_after_shuffle`
+produces a silent shape mismatch hours into alignment training); and no YAML
+carries a key the Python config objects would silently drop.
+
+```bash
+# verify: config-contracts
+cd "${CLAUDE_PROJECT_DIR:-$PWD}" || exit 1
+PY=python3; { command -v uv >/dev/null 2>&1 && [ -d .venv ]; } && PY="uv run --no-sync python"
+$PY - <<'EOF'
+import ast, pathlib, sys, yaml
+
+bad = []
+
+class Loader(yaml.SafeLoader):
+    pass
+Loader.add_multi_constructor("!", lambda l, s, n: None)
+
+docs = {}
+for p in sorted(pathlib.Path("config").rglob("*.yaml")):
+    try:
+        docs[p] = yaml.load(p.read_text(encoding="utf-8"), Loader=Loader) or {}
+    except Exception as exc:
+        bad.append(f"{p}: unparseable: {type(exc).__name__}: {str(exc)[:100]}")
+
+s = docs.get(pathlib.Path("config/vision/siglip.yaml"), {})
+if s:
+    g = s["image_size"] // s["patch_size"]
+    d = s["downsample_factor"]
+    p_ = s["padded_grid_size"]
+    for k, got, want in [
+        ("vision_grid_size", s["vision_grid_size"], g),
+        ("num_vision_tokens", s["num_vision_tokens"], g * g),
+        ("padded_grid_size", p_, g + (g % d)),
+        ("num_tokens_after_shuffle", s["num_tokens_after_shuffle"], (p_ // d) ** 2),
+        ("pixel_shuffle_embed_dim", s["pixel_shuffle_embed_dim"], s["vision_hidden_size"] * d**2),
+    ]:
+        if got != want:
+            bad.append(f"config/vision/siglip.yaml: {k}={got}, derived={want}")
+
+def names(path, kind):
+    p = pathlib.Path(path)
+    out = set()
+    if not p.exists():
+        return out
+    for cls in (n for n in ast.parse(p.read_text(encoding="utf-8")).body
+                if isinstance(n, ast.ClassDef)):
+        for st in cls.body:
+            if kind == "field" and isinstance(st, ast.AnnAssign) and isinstance(st.target, ast.Name):
+                out.add(st.target.id)
+            if kind == "init" and isinstance(st, ast.FunctionDef) and st.name == "__init__":
+                out.update(a.arg for a in st.args.args + st.args.kwonlyargs)
+    out.discard("self")
+    return out
+
+model_params = names("config/model_config.py", "init")
+train_fields = set()
+for f in ("config/training_config.py", "config/multilingual_config.py", "config/lora_config.py"):
+    train_fields |= names(f, "field")
+NESTED = {"lora"}  # structural sub-blocks, not dataclass fields
+
+for y in sorted(pathlib.Path("config/vision").glob("*.yaml")):
+    unknown = sorted(set(docs.get(y, {})) - model_params)
+    if unknown:
+        bad.append(f"{y}: keys unknown to TinyAyaVisionConfig.__init__: {unknown}")
+for y in sorted(pathlib.Path("config/training").glob("*.yaml")):
+    unknown = sorted(set(docs.get(y, {})) - train_fields - NESTED)
+    if unknown:
+        bad.append(f"{y}: keys unknown to the training dataclasses: {unknown}")
+
+print("\n".join(bad) if bad else f"config-contracts-ok ({len(docs)} yaml)")
+sys.exit(1 if bad else 0)
+EOF
+```
+
+## 4. lm-eval task registry resolves
+
+123 task files across 6 suites. Every `!function utils.X` must resolve to a name
+the sibling `utils.py` actually exports, and every `include:` target must exist.
+lm-eval only reports these at task-load time, minutes into a job.
+
+Module-level *assignments* count as exports — `mtvqa/utils.py` builds
+`process_docs_ar` .. `process_docs_vi` from a factory, so a def-only scan would
+produce 18 false positives.
+
+```bash
+# verify: eval-task-registry
+cd "${CLAUDE_PROJECT_DIR:-$PWD}" || exit 1
+PY=python3; { command -v uv >/dev/null 2>&1 && [ -d .venv ]; } && PY="uv run --no-sync python"
+$PY - <<'EOF'
+import ast, pathlib, re, sys, yaml
+
+class Loader(yaml.SafeLoader):
+    pass
+Loader.add_multi_constructor("!", lambda l, s, n: None)
+
+bad, n = [], 0
+for d in sorted(p for p in pathlib.Path("evaluation/tasks").iterdir() if p.is_dir()):
+    util = d / "utils.py"
+    names = set()
+    if util.exists():
+        for node in ast.parse(util.read_text(encoding="utf-8")).body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                names.add(node.name)
+            elif isinstance(node, ast.Assign):
+                names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+            elif isinstance(node, (ast.Import, ast.ImportFrom)):
+                names.update(a.asname or a.name.split(".")[0] for a in node.names)
+    for y in sorted(list(d.rglob("*.yaml")) + list(d.rglob("_default_yaml"))):
+        n += 1
+        text = y.read_text(encoding="utf-8")
+        try:
+            yaml.load(text, Loader=Loader)
+        except Exception as exc:
+            bad.append(f"{y}: unparseable: {type(exc).__name__}: {str(exc)[:100]}")
+            continue
+        for inc in re.findall(r"^\s*include:\s*[\"']?([^\"'\s]+)", text, re.M):
+            if not (y.parent / inc).exists():
+                bad.append(f"{y}: include target missing: {inc}")
+        for ref in re.findall(r"!function\s+([A-Za-z_][\w.]*)", text):
+            mod, _, fn = ref.rpartition(".")
+            if mod == "utils" and fn not in names:
+                bad.append(f"{y}: !function {ref} unresolved in {util}")
+print("\n".join(bad) if bad else f"eval-task-registry-ok ({n} task files)")
+sys.exit(1 if bad else 0)
+EOF
+```
+
+## 5. The memory system itself is intact
+
+Every hook named in `settings.json` exists and imports, all four memory files
+exist, and the PROGRESS ordering anchor survives. Catches a half-installed or
+half-`git clean`ed `.claude/`.
+
+```bash
+# verify: memory-system
+cd "${CLAUDE_PROJECT_DIR:-$PWD}" || exit 1
+python3 -B - <<'EOF'
+import json, pathlib, re, sys
+
+sys.path.insert(0, ".claude/hooks")
+bad = []
+c = pathlib.Path(".claude")
+
+try:
+    settings = json.loads((c / "settings.json").read_text(encoding="utf-8"))
+except Exception as exc:
+    print(f"settings.json unreadable: {exc}")
+    sys.exit(1)
+
+for event, groups in (settings.get("hooks") or {}).items():
+    for g in groups:
+        for h in g.get("hooks", []):
+            m = re.search(r"\.claude/hooks/([\w.]+\.py)", h.get("command", ""))
+            if not m:
+                bad.append(f"{event}: command does not reference a .claude/hooks script")
+            elif not (c / "hooks" / m.group(1)).exists():
+                bad.append(f"{event}: missing .claude/hooks/{m.group(1)}")
+
+for f in ("PLAN.md", "PROGRESS.md", "VERIFY.md", "memories.md"):
+    if not (c / f).exists():
+        bad.append(f"missing .claude/{f}")
+
+prog = c / "PROGRESS.md"
+if prog.exists() and "<!-- progress:marker -->" not in prog.read_text(encoding="utf-8"):
+    bad.append("PROGRESS.md lost its ordering anchor; entries will append oldest-first")
+
+# The orchestration integration spans three places: constants in _lib.py, injection in
+# session_start.py, and content in a separate tree. Remove any one and the other two
+# still look fine -- which is exactly the state this repo had to recover from once.
+# Every assertion is gated on the tree existing, so this is green before and after.
+orch = c / "orchestration"
+if orch.is_dir():
+    for f in ("README.md", "CONTROL_PLANE.md", "SPEC.md", "TPU_OPTIMIZATION_SPEC.md",
+              "playbook/tier-definitions.md", "playbook/diagnosis-table.md"):
+        if not (orch / f).exists():
+            bad.append(f"missing .claude/orchestration/{f}")
+    lib_src = (c / "hooks" / "_lib.py").read_text(encoding="utf-8")
+    for const in ("ORCHESTRATION_DIR", "ORCHESTRATION_README",
+                  "ORCHESTRATION_CONTROL_PLANE", "ORCHESTRATION_TPU_OPT_SPEC"):
+        if const not in lib_src:
+            bad.append(f"_lib.py lost {const}: orchestration wiring is half-removed")
+    if "ORCHESTRATION_CONTROL_PLANE" not in (c / "hooks" / "session_start.py").read_text(encoding="utf-8"):
+        bad.append("session_start.py no longer injects CONTROL_PLANE.md")
+    if not (c / "agents" / "tpu-diagnoser.md").exists():
+        bad.append("playbook/diagnosis-table.md points at a tpu-diagnoser.md that is gone")
+    # The diagnosis table must exist in exactly one place. Five drifting copies is the
+    # documented failure mode of the upstream this was ported from.
+    for pb in (orch / "playbook").glob("*.md"):
+        if "| Signature" in pb.read_text(encoding="utf-8"):
+            bad.append(f"{pb} looks like a second diagnosis table; the agent is canonical")
+    # Scripts named in the README's implementation table must exist. Self-timing:
+    # only enforced once scripts/tpu/ lands.
+    if pathlib.Path("scripts/tpu").is_dir():
+        named = set(re.findall(r"scripts/tpu/([\w.-]+\.(?:sh|py))",
+                               (orch / "README.md").read_text(encoding="utf-8")))
+        for s in sorted(named):
+            if not (pathlib.Path("scripts/tpu") / s).exists():
+                bad.append(f"orchestration/README.md points at missing scripts/tpu/{s}")
+
+try:
+    import _lib, post_tool_use, pre_compact, session_end, session_start, stop, user_prompt_submit  # noqa: F401
+except Exception as exc:
+    bad.append(f"hook import failed: {type(exc).__name__}: {exc}")
+
+print("\n".join(bad) if bad else "memory-system-ok")
+sys.exit(1 if bad else 0)
+EOF
+```
+
+## 6. The backend seam holds
+
+`src/backend/tpu_backend.py` is the only module allowed a module-level
+`import torch_xla`. A leak anywhere in `src/`, `models/`, `pipeline/`, `config/`, or
+`evaluation/` drags `libtpu` into the import graph and breaks every CPU/GPU run and all
+129 tests -- at import time, so the failure lands nowhere near its cause.
+
+```bash
+# verify: backend-seam
+cd "${CLAUDE_PROJECT_DIR:-$PWD}" || exit 1
+bash scripts/ci/check_backend_seam.sh
+```
+
+---
+
+## Not run by the Stop hook
+
+Too slow, or currently red. Run via `/verify-full`, or before a PR. These fences
+are ` ```sh `, so the Stop hook skips them.
+
+Full test suite — 129 tests, 171s, and 17 `OSError: gated repo` errors on
+`CohereLabs/tiny-aya-{base,global}` without an HF token. Belongs in CI (PLAN P2):
+
+```sh
+uv run --no-sync pytest tests/ -q
+```
+
+The non-gated subset, 110 passed in 22s — still too slow for a per-response hook:
+
+```sh
+uv run --no-sync pytest tests/ -q \
+  --ignore=tests/test_processing.py --ignore=tests/test_vlm_assembly.py
+```
+
+Dependency-manifest agreement — red today (PLAN P3): `requirements.txt` lists
+`hydra-core`, `orjson`, and `unsloth` that `pyproject.toml` does not, and omits
+`hydra-zen`, `matplotlib`, and `modal`. `unsloth` was deliberately dropped in
+c5826fd to unbreak `uv sync`:
+
+```sh
+comm -3 \
+  <(sed 's/[<>=!].*//' requirements.txt | tr -d ' ' | grep -v '^$' | sort -u) \
+  <(grep -oP '^\s+"\K[A-Za-z0-9_.-]+' pyproject.toml | sort -u)
+```
+
+Checkpoint paths are not pinned to one contributor's Modal volume — red today
+(PLAN P4). Promote to a ` ```bash ` block once P4 lands:
+
+```sh
+! grep -rnE '/[0-9a-f]{8}-[0-9a-f-]{27}/' config/training/*.yaml
+```
+
+## Proposed checks
+
+`#verify <bash>` quick-capture appends here as a ` ```sh ` fence. Nothing in
+this section runs until you promote it to a ` ```bash ` block above, give it a
+`# verify: <id>` first line, and confirm it finishes in under 2s.

--- a/.claude/agents/memory-curator.md
+++ b/.claude/agents/memory-curator.md
@@ -1,0 +1,66 @@
+---
+name: memory-curator
+description: Periodic review (manual /curate) of the memory system - dedupe, prune, archive, and emit a "what changed since last curation" digest.
+model: inherit
+tools: Read, Edit, Glob, Grep
+---
+
+# memory-curator
+
+Subagent role: keep the memory system from rotting. Runs the `archive-progress`
+skill, dedupes near-identical PROGRESS entries, flags stale memories, and
+updates the README of `.claude/archive/`.
+
+## When invoked
+
+- Manually via `/curate`.
+- Before a major version cut where you want a clean log.
+- When `wc -l .claude/PROGRESS.md` passes ~500.
+
+## Inputs
+
+- (none) — operates on the four memory files plus archive.
+
+## Output
+
+A short markdown digest in chat with these sections:
+
+- `Pruned`: count of entries archived and from which date range.
+- `Deduped`: pairs of similar entries collapsed into one.
+- `Stale memories`: entries in `memories.md` that look obsolete (not referenced
+  by recent PROGRESS, no SUPERSEDED tag, last activity > 180 days). Suggest
+  user actions.
+- `PLAN drift`: items in PLAN.md whose phrasing no longer matches any PROGRESS
+  or VERIFY entry. Flag for the user.
+
+## Steps
+
+1. Run the `archive-progress` skill. Capture the count.
+2. Read PROGRESS.md. For each pair of entries within 24h whose summary lines
+   differ by < 5 chars, merge them (keep the newer timestamp; concatenate
+   detail blocks).
+3. Read memories.md. For each `### YYYY-MM-DD: ...` decision, check the most
+   recent PROGRESS reference. If none in 180 days and no `SUPERSEDED` tag, list
+   as stale.
+4. Read PLAN.md. For each `- [ ]` item, grep the rest of the memory system for
+   keywords. If no hits, list as drifted.
+5. Render the digest. Do NOT auto-edit memories.md or PLAN.md based on
+   stale/drift findings — only flag.
+
+## Constraints
+
+- Read-only on memories.md and PLAN.md (the curator suggests, the user edits).
+- Edits PROGRESS.md only via the `archive-progress` skill or the dedupe pass.
+- Never touches archive files — they are read-only.
+- The digest stays in chat; write nothing outside `.claude/`.
+
+## Success criteria
+
+- Digest fits in < 200 lines.
+- Counts reconcile: entries removed = entries archived + entries deduped.
+
+## Failure modes
+
+- Archive directory unwritable -> abort the prune step; still produce the
+  dedupe digest.
+- PROGRESS.md not parseable -> emit a single warning line and stop.

--- a/.claude/agents/plan-driver.md
+++ b/.claude/agents/plan-driver.md
@@ -1,0 +1,69 @@
+---
+name: plan-driver
+description: Turn a fuzzy goal into a concrete .claude/PLAN.md (checklist + Definition of Done + phased tasks). Invoked when no PLAN exists for the current branch, or when the user asks to regenerate one with /plan.
+model: inherit
+tools: Read, Glob, Grep, Write, Edit, Bash
+---
+
+# plan-driver
+
+Subagent role: produce a clean, executable PLAN.md aligned with the real state
+of the repo and the user's stated goal.
+
+## Inputs
+
+- The user's goal in natural language.
+- The current branch (`git rev-parse --abbrev-ref HEAD`, read-only).
+- The current PROGRESS.md (last 50 lines) and memories.md (decisions).
+- Root `CLAUDE.md` for project conventions.
+
+## Output
+
+A single file written to `.claude/PLAN.md` containing:
+
+- `# PLAN.md — current goal`
+- A `## Goal` paragraph.
+- A `## Definition of Done` checklist (5-12 items).
+- A `## Tasks` section with phased subsections. **The literal heading
+  `## Tasks` is required** — the `#plan` quick-capture router appends under it.
+- An `## Out of scope` list.
+- An `## Invariants` section for facts that must stay true across the work.
+
+## Steps
+
+1. Read PROGRESS.md, memories.md, and root `CLAUDE.md`.
+2. Reconcile the user's goal against the most recent PLAN (if any).
+   - Same goal: refine in place; do not delete.
+   - Different: archive the prior PLAN under
+     `.claude/archive/PLAN-<YYYY-MM-DD>.md` and write a new one.
+3. Decompose the goal into 3-5 phases. Each phase is 2-5 tasks.
+4. Definition of Done items must be **observable** — a command runs, a file
+   exists, a number is below a threshold. Subjective items ("clean code") are
+   not allowed.
+5. Where a DoD item is covered by a check in VERIFY.md, tag the line with
+   `<!-- verify:<id> -->` using that block's id. The Stop hook auto-ticks it.
+6. Out-of-scope needs at least one item; if everything is in scope the goal is
+   too broad.
+7. Write the file. Do not modify PROGRESS.md or memories.md.
+
+## Constraints
+
+- No emojis.
+- Plan items must be actionable in the next single session.
+- Do not invent verification commands; defer to VERIFY.md.
+- If the goal is ambiguous, ask **one** clarifying question before generating.
+  If you cannot resolve it, generate a plan under the most plausible reading
+  with an explicit "TODO: confirm assumption X" item.
+
+## Success criteria
+
+- PLAN.md parses as markdown and contains a literal `## Tasks` heading.
+- Every Definition of Done checkbox is observable.
+- The plan references files, commands, and configs that actually exist.
+
+## Failure modes
+
+- Cannot read the memory files -> abort and point the user at
+  `.claude/MEMORY-SYSTEM.md` to reinstall.
+- Goal is fundamentally underspecified -> produce a single `## Open questions`
+  section in PLAN.md instead of a checklist.

--- a/.claude/agents/tpu-diagnoser.md
+++ b/.claude/agents/tpu-diagnoser.md
@@ -1,0 +1,91 @@
+---
+name: tpu-diagnoser
+description: Deterministic log-signature classifier for Tiny Aya Vision torch_xla/TPU failures. Feed it log excerpts and a met.metrics_report() dump; it returns classification, tier, and the recommended action.
+model: inherit
+tools: Read, Grep
+---
+
+# tpu-diagnoser
+
+This table is **canonical**. `.claude/orchestration/playbook/diagnosis-table.md` points
+here rather than duplicating it. Tier meanings and policy live in
+`.claude/orchestration/playbook/tier-definitions.md`.
+
+Classify **first match wins**, top to bottom. When two rows match, prefer the
+higher-intervention one. Return: classification, the matching line(s), tier, and the
+recommended action verbatim. Never edit files, restart processes, or touch queued
+resources — report, and let the orchestrator act.
+
+## Provenance
+
+- **[xla]** — inherited from `tinyaya-stage2-scale` (torch_xla, same Cohere2 backbone).
+  Observed there, not yet here.
+- **[infra]** — inherited from `llm-architectures`. Stack-independent; these are
+  properties of GCE/TRC/boot, and transfer exactly.
+- **[vlm]** — new, derived from *this repo's code* with a named location. **Predictions,
+  not history** — no Tiny Aya Vision TPU run has happened. Treat a [vlm] row as "here is
+  where to look first", not "this is what went wrong before".
+
+| # | Signature (regex-ish) | Classification | Action | Tier |
+|---|---|---|---|---|
+| 1 | `ImportError.*libpython3\.12\.so\.1\.0` **[xla]** | `libpython` — `_XLAC.so` dynamically links libpython, which uv keeps outside the loader path | `startup_script.sh` must export `LD_LIBRARY_PATH` from the uv Python root. Present since the port; if this fires, that block was dropped or uv moved its root. | T2 |
+| 2 | `OSError.*gated repo` OR `401 Client Error.*tiny-aya` OR `Cannot access gated repo` **[vlm]** | `hf-gated` — `CohereLabs/tiny-aya-{base,global}` needs an authorised `HF_TOKEN`, which reaches the VM only inside the tarball's `.env` | Run `ops.sh preflight` **before** deploying. Confirm `.env` exists at repo root, carries `HF_TOKEN`, and that the token has access. Neither source repo has gated weights; this fires before step 1 on every worker and is unique to this project. | T2 |
+| 3 | `code tarball not found` **[infra]** | `boot-code-missing` | Upload via `deploy_tarball.sh`, or resubmit via `launch_spot.sh` (auto-tars at submit). | T2 |
+| 4 | `Unable to acquire the dpkg frontend lock` **[infra]** | `boot-apt-race` | `startup_script.sh` retries; if a worker is still stuck, re-run its startup **detached** — never a foreground ssh with a local `timeout`. | T1→T2 |
+| 5 | `Failed to deserialize executable: UNIMPLEMENTED` **[xla]** | `xla-cache` — persistent-cache entry unreadable | Remove `XLA_PERSISTENT_CACHE_PATH`. The cache has **nondeterministic keys on v6e SPMD and never warm-hits anyway**; it buys nothing and costs this failure. It is off in the protected config. | T2 |
+| 6 | `loss.*(nan\|NaN\|inf)` around step 20-150, FSDPv2 active **[xla]** | `fsdp-reduce-scatter-nan` — 36 per-layer `Cohere2DecoderLayer` wraps → 36 bf16 reduce-scatters → pytorch/xla #8591 / #8778 | **Do not retry.** Remove the decoder-layer class from the auto-wrap policy so there is one outer reduce-scatter. FSDPv2 has no `fp32_reduce_scatter` (FSDPv1 only, #3588/#8056). On this model the clean move is `TPU_STRATEGY=replicated`, which the parameter budget permits — `TPU_OPTIMIZATION_SPEC.md` §4. | T4 |
+| 7 | FSDPv2 reports 0 wrapped modules, OR per-chip HBM ≈ full model size **[vlm]** | `fsdp-wrapped-nothing` — the policy matches `type(module).__name__`; a stale class name wraps zero modules and silently falls back to replicated | Print the wrap count at startup. **For Phase 1 this is expected and fine** (11.5M trainable of 3.75B) — use `replicated` explicitly rather than an FSDPv2 that no-ops. For Phase 2, verify the class name against the installed `transformers`. | T2 |
+| 8 | `RESOURCE_EXHAUSTED` OR `Out of memory` OR `exit code 137` **[xla]** | `oom` | Cut **images per step** first — a VLM's activation peak scales with images × 196 tokens, not text length. Hold the effective batch with grad-accum. Ceiling is 29 GiB of 31.25 usable on v6e. | T2 |
+| 9 | `Image token count \(\d+\) != image feature count` **[vlm]** | `image-token-mismatch` — `models/tiny_aya_vision.py`; the processor expanded a different number of `<image>` placeholders than the encoder produced | A config mismatch between `config/vision/*.yaml` and the processor. Run `.claude/VERIFY.md`'s `config-contracts` block locally — it derives all five token quantities and catches this without burning a slice. | T2 |
+| 10 | `xla/compile_cause_count` rising monotonically with steps, no error, MoonViT active **[vlm]** | `dynamic-shape-recompile-moonvit` — `src/processing.py` returns `H*W` per image from `image_grid_hws`, so sequence length varies per batch and XLA compiles per shape | **MoonViT is not TPU-eligible unbucketed.** Pin SigLIP (fixed 196), or implement `TPU_OPTIMIZATION_SPEC.md` Phase 6 buckets with every bucket graph prewarmed. Do not try to close PLAN P1 on TPU. | T2 |
+| 11 | `aten::nonzero` in the fallback counters, OR step time correlated with images-per-batch **[vlm]** | `dynamic-scatter` — `models/tiny_aya_vision.py` uses `special_image_mask.nonzero(as_tuple=False)` + advanced indexing | **This is a CUDA workaround that is wrong on XLA.** `index_put` was chosen because `masked_scatter_backward` mis-shapes under inductor; `nonzero` is a dynamic-shape op that on XLA falls back to CPU or recompiles per distinct image count. Needs a static-shape form behind the backend seam — **not** an unconditional revert to `masked_scatter`, which breaks the GPU path. Candidate `opt-6-nonzero`. | T2 |
+| 12 | `aten::_local_scalar_dense` once per step, no error **[vlm]** | `guard-sync` — `n_image_tokens.item()` in `_merge_image_features`. The `torch.compiler.is_compiling()` bypass above it is a **Dynamo** predicate and is False under torch_xla LazyTensor tracing, so the guard syncs every forward | Confirm with `met.metrics_report()` on the first smoke run before acting. Fix is to widen the bypass to cover XLA tracing, or move the check behind a debug flag. Candidate `opt-0-metrics`. | T1 |
+| 13 | Compile count explodes at the sample-generation step; run never returns **[vlm]** | `generate-recompile` — `train_alignment.py` calls `generate_samples()` for logging; `_prepare_cache_for_generation` forces `DynamicCache`, whose growing shape means a new HLO program per decoded token | Disable in-training sample generation on TPU. The `DynamicCache` override exists to dodge a Cohere2 `HybridCache` prefill hang on **CUDA** and does not transfer. | T2 |
+| 14 | Compile-cause count rising, no error, elapsed < 30 min **[xla]** | `compile-normal` | Continue. ~14 min cold-boot recompile is normal on this stack. | T0 |
+| 15 | TPU duty ≈ 0% + HBM > 50% + no step line + elapsed > **20 min** **[xla]** | `compile-stall` | Ensure `python -u`, confirm `XLA_PERSISTENT_CACHE_PATH` is unset, dump `met.metrics_report()`. **Elapsed alone cannot classify this** — read the compile-cause counter. Check rows 10-13 first; three of the four VLM signatures present as a stall. | T1→T2 |
+| 16 | Compile-cause count rising, no error, elapsed > 60 min **[xla]** | `compile-runaway` | Add `XLA_IR_DEBUG=1` on the next deploy and diff graph shapes. Rows 10-13 again — a dynamic shape is the usual cause, and it is one line of Python, not an XLA bug. | T2 |
+| 17 | `PJRT.*DEADLINE_EXCEEDED` OR `Coordination service.*Deadline`, multi-host only **[infra]** | `rendezvous-failure` — a worker never joined | v6e-8 is single-host and cannot produce this. On a multi-host profile check **all** workers' `/tmp/startup.log`; re-run startup on stragglers **detached**, then redeploy. Root cause seen upstream: an apt/dpkg lock race at boot, not the framework. | T2 |
+| 18 | `Run ID cannot be empty` **[infra]** | `wandb-empty-env` | An empty `WANDB_*` export reached `wandb.init`. Launchers must export only when non-empty **and** the init path must scrub empties — either half alone has failed. | T2 |
+| 19 | `no WANDB_API_KEY found` **[infra]** | `wandb-no-op` | `.env` did not reach the VM. The run still trains — but **check row 2 first**, because the same missing `.env` also means no `HF_TOKEN`, and that one is fatal. | T1 |
+| 20 | `This TPU has terminal state "PREEMPTED"` **[infra]** | `preempted` | `qr_watch` should recycle. If tmux `qrwatch-tayavision` is dead, restart it. See row 23 for the durability gate. | T3 |
+| 20a | QR `PROVISIONING` → `SUSPENDING` → `FAILED` in <5 min, `stateInitiator: SERVICE`, `failedData.error.code: 13` `"an internal error has occurred"` **[observed 2026-07-25, this repo]** | `slice-too-large` — the service allocated capacity, then took it back. **Not a quota gate.** Verified: `europe-west4` `IN_USE_ADDRESSES` was 16/64 (48 free) and it failed anyway; there is no `TPU_V6E_*` compute-quota row to check at all. | Do not retry the same size, and **do not raise IP quota** — that hypothesis is falsified (`docs/tpu/tpu-capacity-log.md` 2026-07-25). Drop to a smaller slice: `v6e-8-eu` is single-host, co-located, and observed gettable in 2-5 min. **Delete the FAILED husk first** — dead QRs book quota. | T4 |
+| 21 | `gcloud ssh.*Connection refused` **[xla]** | `node-corruption` | T3 per `tier-definitions.md`. | T3 |
+| 22 | `kernel panic` OR `Bus error` **[xla]** | `node-corruption` | As row 21. | T3 |
+| 23 | Node lost AND `SAVE_CKPT_DIR` is not a `gs://` URI **[vlm]** | `recycle-blocked-nondurable` | **Auto-recycle is declined on purpose.** Recycling here restarts from step 0 and re-pays ~14 min of compile, up to twenty times, silently. Point `SAVE_CKPT_DIR` at `gs://tayavision-eu/...` and redeploy. `SPEC.md` §5. | T4 |
+| 24 | N worker PIDs unreachable for 3+ consecutive polls **[xla]** | `node-corruption` | As row 21. Prefer this over any compile/stall row — a dead PID is a stronger signal than an idle chip. | T3 |
+| 25 | Orchestrator says the run is live; the VM log says `exited with status` **[infra]** | **`watcher blindness, not a run failure`** — the completion probe truncated its own output. A `head -N` over a stream containing repeating per-step lines pushes the exit marker past N. | Confirm on the VM before touching anything. Read status markers from the **tail**; fetch repeating lines in a separate query. **When a watcher and reality disagree, the watcher is wrong until proven otherwise.** | T0 |
+| 26 | Same classification as the previous iteration | `repeat` | Circuit breaker. Stop — the patch is not working, and each retry costs ~14 min of recompile. | T4 |
+| 27 | None of the above | `unknown` | Escalate. Add the signature once diagnosed — procedure in `playbook/diagnosis-table.md`. | T4 |
+
+## Overrides
+
+1. If `iteration > 1` and the classification equals the previous one, override to row 26.
+2. If any node-death row (21, 22, 24) matches at all, prefer it over any compile or stall
+   row.
+3. Prefer a signature matching the **cause** over one matching a downstream symptom. Rows
+   10-13 all surface as "compile count rising"; row 16 alone would send you to XLA for a
+   day when the cause is one line of Python.
+4. If `TPU_STRATEGY=replicated` and a row mentions FSDPv2, the row does not apply — say
+   so rather than forcing a match.
+
+## Phase-7 hazards (not live rows)
+
+These three are real torch_xla signatures but fire only with `use_scan_layers: true`,
+which the protected config sets to `false`. They live here as hazards of the
+`opt-7-scan` probe, not as classifications:
+
+- `ValueError.*Layer \d+ has mismatched keys` — `scan_layers` `_ensure_same_structure`.
+  **More likely here than upstream**: Phase 2 puts LoRA on layers 18-35 only, so layers
+  0-17 differ structurally by construction.
+- `AssertionError.*FakeTensor.*aten\.index_select` — `is_layer_pure=True` with a
+  position-embedding gather.
+- `TypeError.*unexpected keyword.*attention_mask` — scan passes positionally; HF layers
+  take kwargs.
+
+## Baselines
+
+**None yet.** No TPU run has occurred.
+`.claude/orchestration/playbook/baseline-v6e8-siglip-cohere2.md` is a template. Do not
+import the sibling repos' numbers as this model's baseline — the only transferable facts
+are the compile-time envelope (~14 min cold boot) and the HBM ceiling (29 GiB on v6e),
+which are properties of the silicon and toolchain rather than of the model.

--- a/.claude/agents/tpu-watchdog.md
+++ b/.claude/agents/tpu-watchdog.md
@@ -1,0 +1,85 @@
+---
+name: tpu-watchdog
+description: Read-only TPU run-state inspector for Tiny Aya Vision torch_xla runs. Use to answer "is the run healthy?" without touching anything.
+model: inherit
+tools: Read, Bash
+---
+
+# tpu-watchdog
+
+**NEVER mutate state.** No deploys, no deletes, no restarts, no QR operations. Collect
+evidence, return one verdict. The orchestrator acts; you report.
+
+## Topology
+
+| Profile | Workers | Chips |
+|---|---:|---:|
+| `v6e-8-eu` (default) | 1 | 8 |
+| `v6e-64-ew4a` / `-ue1d` | 8 | 64 |
+| `v5e-64-ew4b` / `-uc1a` | 16 | 64 |
+| `v4-32-uc2b` | 4 | 32 |
+
+Identify node and zone from the operator's prompt or the launch env. Project is
+`ml-pipelines-315702` unless overridden.
+
+## Evidence to collect
+
+1. **QR state**
+   ```
+   gcloud compute tpus queued-resources describe <qr> --zone=<z> \
+     --project=ml-pipelines-315702 --format='value(state.state)'
+   ```
+2. **Run log tail** — worker 0, and scoped to the newest segment (after the last
+   `launching ... tag=` line):
+   ```
+   gcloud compute tpus tpu-vm ssh <node> --zone=<z> --worker=0 --quiet \
+     --command="tail -n 40 /tmp/train.log"
+   ```
+   Take status markers from the **tail**. Fetch the repeating per-step line in a
+   **separate** query. Piping both through one `head -N` truncates the rare marker behind
+   N repeats of the noisy one — that is diagnoser row 25, and it once hid a completed run
+   for an hour.
+3. **XLA compile counters** — the discriminator that elapsed time cannot give you:
+   ```
+   ... --command="grep -E 'CompileTime|aten::(nonzero|_local_scalar_dense)' /tmp/train.log | tail -20"
+   ```
+   A **flat** compile-cause count means steady state. A **rising** one mid-run means a
+   shape is varying — go to diagnoser rows 10-13 before concluding anything about speed.
+4. **Workstation state** — `tail -20 /tmp/qr_watch_tayavision.log`, and `tmux ls` for the
+   `qrwatch-tayavision` session. Note the suffix: a bare `qrwatch` on this workstation
+   belongs to `llm-architectures`.
+5. **W&B heartbeat**, only if asked — project `cataluna84/tayavision-tpu`.
+
+## Verdicts — return exactly one
+
+| Verdict | Criteria |
+|---|---|
+| `progressing` | Step lines advancing within the last ~3 min, compile count flat |
+| `compiling` | Launch marker present, no step lines, no errors, **< 20 min** since launch |
+| `stalled` | No new step line for > 5 min, process alive, no terminal error, **and** the compile count is flat |
+| `crashed` | `Traceback` / `RESOURCE_EXHAUSTED` / `nan` / `exited with status` non-zero in the current segment |
+| `preempted` | QR not `ACTIVE` |
+| `success` | Clean `exited with status 0` in the current segment |
+
+**The 20-minute `compiling` threshold is deliberate and differs from the JAX sibling's
+10.** torch_xla on v6e SPMD takes ~14 min to compile on a cold boot because the
+persistent cache has nondeterministic keys and never warm-hits. A 10-minute rule reports
+`stalled` on every single launch. Never call `stalled` on elapsed time alone — check that
+the compile count is flat first.
+
+## Return format
+
+- The verdict, on its own line.
+- One line of evidence per source, quoting the actual matched text.
+- Last step number, step time, and images/sec if available.
+- The single most useful next command.
+
+If the run looks wrong, name the likely diagnoser row rather than guessing at a fix —
+classification is `tpu-diagnoser`'s job, and recovery is the orchestrator's.
+
+## When there is nothing to watch
+
+If no QR exists, say so plainly and stop. Do not launch one. If the entrypoint is
+`scripts/tpu/tpu_smoke.py`, note that this is the **control-plane smoke**, not training —
+`pipeline/train_*.py` does not run on TPU yet (`orchestration/SPEC.md` §9). A green smoke
+proves provisioning, not that the model trains.

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -1,0 +1,51 @@
+---
+name: verifier
+description: Run the verify skill in CI-style isolation; produce a structured pass/fail report. Used by the /verify slash command.
+model: inherit
+tools: Read, Bash
+---
+
+# verifier
+
+Subagent role: a focused executor of the `verify` skill. Returns a structured
+report and nothing else.
+
+## Inputs
+
+- (none) — reads `.claude/VERIFY.md` directly.
+
+## Output
+
+A markdown table with columns: `#`, `id`, `status` (pass/fail/skipped),
+`time` (seconds), `exit`, `tail` (last line of output). Plus a one-line summary
+of the overall outcome.
+
+## Steps
+
+1. Invoke the `verify` skill.
+2. Add a summary block at the top (`X passed, Y failed, Z skipped`).
+3. If anything failed, list the failed block ids with their tails.
+4. Append a `done | verify` or `fail | verify` entry to PROGRESS.md via the
+   `update-progress` skill.
+
+## Constraints
+
+- Run only the ` ```bash ` blocks in VERIFY.md. Blocks fenced ` ```sh ` are
+  documentation and proposals — never execute them. `/verify-full` is where the
+  slow ones live.
+- Do not modify any file under VERIFY.md's command surface.
+- Per-block ceiling 15s; total wall time under 75s, matching the Stop hook.
+- Honor `MEMORY_VERIFY_ONLY=<block-id>` to run a single block by its
+  `# verify: <id>` line.
+
+## Success criteria
+
+- The report is self-contained: a reader can see exactly which blocks ran, with
+  what exit code, in what time.
+- No unexpected files written. `git status` is unchanged afterwards.
+
+## Failure modes
+
+- VERIFY.md missing -> emit a single warning and return.
+- A block hangs -> kill it at 15s and mark it failed with `tail=timeout`.
+- A block reports `skip: ...` and exits 0 -> record as `skipped`, not `pass`.

--- a/.claude/commands/curate.md
+++ b/.claude/commands/curate.md
@@ -1,0 +1,26 @@
+---
+description: Run the memory-curator subagent to dedupe, prune, and archive old PROGRESS entries and emit a "what changed" digest.
+---
+
+Delegate to the `memory-curator` subagent (see
+`.claude/agents/memory-curator.md`).
+
+Steps:
+
+1. Invoke the curator via the Agent tool.
+2. The curator will:
+   - Run the `archive-progress` skill (move entries older than 90 days into
+     `.claude/archive/PROGRESS-YYYY-Qn.md`).
+   - Dedupe near-identical PROGRESS entries within 24h windows.
+   - Identify stale `memories.md` decisions (no PROGRESS reference in 180 days,
+     no `SUPERSEDED` tag).
+   - Identify drifted PLAN items (no keyword match in PROGRESS or VERIFY).
+3. Render the curator's digest verbatim.
+4. The curator does NOT auto-fix `memories.md` or `PLAN.md`. It only flags
+   items for human review.
+
+Out of scope:
+
+- Auto-deleting decisions: humans must mark them SUPERSEDED.
+- Auto-removing PLAN items: humans must `- [x]` or remove them.
+- Compressing archive files: archives are append-only forever.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,31 @@
+---
+description: Generate or regenerate .claude/PLAN.md from the current goal using the plan-driver subagent.
+argument-hint: <optional explicit goal>
+---
+
+Delegate to the `plan-driver` subagent (see `.claude/agents/plan-driver.md`) to
+produce or regenerate `.claude/PLAN.md`.
+
+Steps:
+
+1. If `$ARGUMENTS` is provided, treat it as the explicit goal. If not, ask the
+   user to state the goal in one sentence.
+2. Read the current `.claude/PLAN.md` (if any) so existing structure is
+   preserved when refining.
+3. Invoke the `plan-driver` subagent via the Agent tool with:
+   - The user's goal
+   - The current branch
+   - A pointer to `.claude/PROGRESS.md` and `.claude/memories.md`
+4. Wait for the subagent's report.
+5. Verify the new PLAN.md:
+   - Has `## Goal`, `## Definition of Done`, `## Tasks`, `## Out of scope`
+     headings. The literal `## Tasks` heading is required — the `#plan`
+     quick-capture router appends under it.
+   - Has at least 5 Definition of Done items, each observable.
+   - Has at least 3 phased Task subsections.
+6. If the subagent produced non-conforming output, ask it to retry once with
+   the constraints made explicit.
+7. Confirm in one line: `plan: regenerated PLAN.md from goal "<...>"`.
+
+Out of scope for this command: editing PROGRESS.md, memories.md, VERIFY.md,
+CLAUDE.md, or AGENTS.md.

--- a/.claude/commands/progress.md
+++ b/.claude/commands/progress.md
@@ -1,0 +1,30 @@
+---
+description: Append a manual entry to .claude/PROGRESS.md (without going through a hook).
+argument-hint: <what to log>
+---
+
+Append `$ARGUMENTS` to `.claude/PROGRESS.md` as the newest entry.
+
+Use the `update-progress` skill with:
+
+- `status: info`
+- `kind: session`
+- `summary: $ARGUMENTS` (truncated to 280 chars)
+
+Format the entry exactly as PROGRESS.md's header block specifies:
+
+```
+## <iso8601 utc> | <branch>@<short-sha> | info | session
+$ARGUMENTS
+```
+
+Insert it immediately below the `<!-- progress:marker -->` line so it becomes
+the topmost dated entry. That marker is the file's ordering contract — see
+`.claude/MEMORY-SYSTEM.md`. If it is missing, re-seed it under the H1 rather
+than appending at the end of the file.
+
+Run the secret-scrub before writing.
+
+If `$ARGUMENTS` is empty, prompt the user for what to log and stop.
+
+Confirm in one line: `memory: appended to PROGRESS.md`.

--- a/.claude/commands/recall.md
+++ b/.claude/commands/recall.md
@@ -1,0 +1,39 @@
+---
+description: Print the current memory state (PLAN, PROGRESS, VERIFY, memories) as structured markdown.
+---
+
+Run the `keep-context-fresh` skill in interactive mode: read the four memory
+files and render a clean state summary. Write nothing.
+
+Output structure:
+
+1. **Heading** — `Memory state`, with the current branch and short sha.
+2. **Goal** — one-line summary from `.claude/PLAN.md`'s `## Goal`.
+3. **Definition of Done** — `n/m complete`, then the unchecked items as a list.
+4. **Open PLAN tasks** — a markdown table of the top 10 unchecked items, with
+   columns `phase`, `item`. Ordered by phase.
+5. **Recent PROGRESS** — a markdown table of the 10 most-recent entries, with
+   columns `when`, `kind`, `status`, `summary`.
+6. **Verify status** — one line drawn from the most recent `verify`-kind entry
+   in PROGRESS.md, e.g. `verify: 5/5 passed on Stop (2026-07-25T09:14:02Z)`.
+   If there is none, say `verify: no run recorded yet`.
+7. **Stop-hook checks** — the `# verify: <id>` ids currently defined in
+   VERIFY.md, comma-separated.
+8. **Decisions** — the count of `### YYYY-MM-DD:` blocks in `memories.md`, plus
+   the three most recent titles.
+
+Steps:
+
+1. Read all four memory files.
+2. Compose the summary as plain markdown — headings, tables, and lists. Do not
+   emit `<json-render>` blocks or any other widget markup; Claude Code renders
+   those as literal text.
+3. Do not write any file.
+
+Failure handling:
+
+- If any of the four memory files is missing, lead with a bold warning line
+  naming the missing file and pointing at `.claude/MEMORY-SYSTEM.md`, then
+  render whatever is available.
+- If PLAN.md has no `## Goal` heading, the Goal section reads
+  `(none — run /plan to generate)`.

--- a/.claude/commands/remember.md
+++ b/.claude/commands/remember.md
@@ -1,0 +1,31 @@
+---
+description: Save a long-term decision or piece of domain knowledge to .claude/memories.md.
+argument-hint: <what to remember>
+---
+
+Append the user's note to `.claude/memories.md` under the `## Project decisions`
+section, formatted as:
+
+```markdown
+### YYYY-MM-DD: <short title derived from the note>
+**Decision:** $ARGUMENTS
+**Captured-from:** /remember
+```
+
+Use today's UTC date. Choose a short title (<= 80 chars) from the first
+sentence of `$ARGUMENTS`.
+
+Steps:
+
+1. Read `.claude/memories.md`.
+2. Locate the `## Project decisions` heading. This exact heading is also what
+   the `#decision` quick-capture router targets — do not rename it.
+3. Insert the new block immediately before the next `## ` heading, or at the
+   end of the section if it is the last one.
+4. Run the secret-scrub regexes (`hf_[a-zA-Z0-9]{20,}`, `sk-…`, `gh[ps]_…`,
+   `AKIA…`, Modal `a[ks]-…`, `WANDB_API_KEY=…`) before writing; replace any
+   match with `[REDACTED]`.
+5. Write the file back.
+6. Confirm in one short line: `memory: saved decision to memories.md`.
+
+If `$ARGUMENTS` is empty, ask the user what to remember and stop.

--- a/.claude/commands/verify-full.md
+++ b/.claude/commands/verify-full.md
@@ -1,0 +1,31 @@
+---
+description: Run the slow checks the Stop hook deliberately skips - full pytest and the currently-red drift checks.
+---
+
+`.claude/VERIFY.md` only contains checks fast enough to run after every
+response (~0.5s total). This command runs the rest.
+
+Steps:
+
+1. `uv run --no-sync ruff check .` — report the count and the top rules. This
+   one is also a Stop-hook block, so it should already be 0; report any drift.
+2. `uv run --no-sync pytest tests/ -q` — 129 tests, budget ~180s.
+   - Expect **17 errors** in `tests/test_processing.py` and
+     `tests/test_vlm_assembly.py` unless an `HF_TOKEN` with access to the gated
+     `CohereLabs/tiny-aya-base` / `-global` repos is present. Report those as
+     `known-red (gated repo)`, not as regressions.
+   - The other 112 must pass. Any failure there is a real regression.
+   - GPU tests self-skip via `requires_gpu` when CUDA is absent.
+   - For a fast signal, the non-gated subset is 110 tests in ~22s:
+     `uv run --no-sync pytest tests/ -q --ignore=tests/test_processing.py --ignore=tests/test_vlm_assembly.py`
+3. Run every ` ```sh ` block in the "Not run by the Stop hook" section of
+   VERIFY.md and report each as pass / fail / known-red. The dependency-manifest
+   and checkpoint-path checks are known-red pending PLAN items P3 and P4.
+4. Append one `done | verify` or `fail | verify` entry to PROGRESS.md
+   summarising all three, via the `update-progress` skill.
+
+Report as a markdown table: `check | status | detail`.
+
+Do not auto-fix. In particular do not run `ruff check --fix` — `pipeline/` and
+`scripts/` are actively edited upstream, and a mechanical reformat there will
+conflict.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,29 @@
+---
+description: Run every ```bash block in .claude/VERIFY.md and produce a structured pass/fail report.
+---
+
+Delegate to the `verifier` subagent (see `.claude/agents/verifier.md`).
+
+Steps:
+
+1. Confirm `.claude/VERIFY.md` exists and is non-empty.
+2. Invoke the `verifier` subagent via the Agent tool. It will:
+   - Run every fenced ` ```bash ` block in VERIFY.md, in order, with a 15s
+     per-block ceiling.
+   - **Skip every ` ```sh ` block** — those are documentation and `#verify`
+     proposals, not live checks. The slow ones live in `/verify-full`.
+   - Render a markdown table of results (`#`, `id`, `status`, `time`, `exit`,
+     `tail`).
+   - Append a `done | verify` or `fail | verify` entry to PROGRESS.md.
+3. Render the subagent's output verbatim.
+4. If anything failed, lead with one line: `verify: FAIL on <block-id>`.
+5. If all pass, tick matching `<!-- verify:<id> -->` items in `.claude/PLAN.md`
+   via the `update-plan` skill.
+
+This command does **not** block the session on failure by default. To make the
+Stop hook blocking, set `MEMORY_STOP_BLOCK_ON_FAIL=1` in your shell before
+launching `claude`. To silence Stop-hook verification entirely, set
+`MEMORY_STOP_DISABLE_VERIFY=1`.
+
+Out of scope: editing VERIFY.md, modifying source code, or auto-fixing
+failures. The verifier reports; the user decides.

--- a/.claude/hooks/_lib.py
+++ b/.claude/hooks/_lib.py
@@ -1,0 +1,169 @@
+"""Shared helpers for memory-system hooks. Imported by sibling hook scripts.
+
+Stdlib only, so the hooks run under any `python3` without a virtualenv.
+
+The ordering contract lives here: PROGRESS.md is newest-first, and new entries
+are inserted directly below `PROGRESS_MARKER`. Both `append_progress` and
+`user_prompt_submit` go through `insert_newest_first` so there is exactly one
+implementation of that rule -- the upstream version had two copies searching for
+a `---` separator that the file never contained, so every entry silently
+appended at EOF and the log ran oldest-first for 572 entries.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+PROJECT_DIR = Path(os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()).resolve()
+CLAUDE_DIR = PROJECT_DIR / ".claude"
+
+PROGRESS_FILE = CLAUDE_DIR / "PROGRESS.md"
+PLAN_FILE = CLAUDE_DIR / "PLAN.md"
+VERIFY_FILE = CLAUDE_DIR / "VERIFY.md"
+MEMORIES_FILE = CLAUDE_DIR / "memories.md"
+ARCHIVE_DIR = CLAUDE_DIR / "archive"
+
+# TPU run-control design docs. Separate from the four memory files because these are
+# *tracked* and shared, where the memory files are per-contributor. Two of them are
+# injected at SessionStart; the README and the run SPEC are read on demand by the
+# tpu-orchestrate skill. Every consumer guards on .exists() -- a branch that predates
+# the orchestration import must not get "<missing: ...>" prepended to every session.
+ORCHESTRATION_DIR = CLAUDE_DIR / "orchestration"
+ORCHESTRATION_README = ORCHESTRATION_DIR / "README.md"
+ORCHESTRATION_CONTROL_PLANE = ORCHESTRATION_DIR / "CONTROL_PLANE.md"
+ORCHESTRATION_TPU_OPT_SPEC = ORCHESTRATION_DIR / "TPU_OPTIMIZATION_SPEC.md"
+
+# The anchor new PROGRESS entries are inserted below. An HTML comment rather
+# than `---`: this system uses YAML front matter in every skill/agent/command
+# file, `---` renders as a setext heading or thematic break, markdown formatters
+# rewrite it, and it appears constantly inside captured tool output.
+PROGRESS_MARKER = "<!-- progress:marker -->"
+
+SECRET_PATTERNS = [
+    re.compile(r"hf_[a-zA-Z0-9]{20,}"),
+    re.compile(r"sk-[a-zA-Z0-9]{20,}"),
+    re.compile(r"gh[ps]_[a-zA-Z0-9]{30,}"),
+    re.compile(r"AKIA[A-Z0-9]{16}"),
+    re.compile(r"BEGIN.*PRIVATE KEY"),
+    # Modal tokens (MODAL_TOKEN_ID / MODAL_TOKEN_SECRET) -- everything heavy in
+    # this repo runs on Modal, so these are the likeliest thing to leak.
+    re.compile(r"\ba[ks]-[A-Za-z0-9]{16,}\b"),
+    # Named credentials in `KEY=value` form. Deliberately not a bare 40-hex
+    # pattern, which would redact every git SHA in the log.
+    re.compile(r"(?i)\b(wandb|hf|hugging\s?face)[_-]?(api[_-]?)?(key|token)\s*[=:]\s*\S+"),
+]
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def git_rev() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(PROJECT_DIR),
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=3,
+        )
+        return out.strip() or "no-git"
+    except Exception:
+        return "no-git"
+
+
+def git_branch() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=str(PROJECT_DIR),
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=3,
+        )
+        return out.strip() or "detached"
+    except Exception:
+        return "no-git"
+
+
+def scrub(text: str) -> str:
+    for pat in SECRET_PATTERNS:
+        text = pat.sub("[REDACTED]", text)
+    return text
+
+
+def rel(path: str) -> str:
+    """Render a path relative to the repo root when it lives inside it.
+
+    Keeps machine-specific absolute paths out of the log.
+    """
+    try:
+        return str(Path(path).resolve().relative_to(PROJECT_DIR))
+    except Exception:
+        return path
+
+
+def read_input() -> dict:
+    try:
+        return json.load(sys.stdin)
+    except Exception:
+        return {}
+
+
+def emit(payload: dict | None = None) -> None:
+    if payload is not None:
+        print(json.dumps(payload))
+
+
+def insert_newest_first(path: Path, block: str) -> None:
+    """Insert `block` immediately below PROGRESS_MARKER (newest entry first).
+
+    `block` is a markdown chunk with no leading or trailing blank lines.
+
+    If the marker is absent we re-seed it under the H1 rather than appending at
+    the end. The old append-at-end fallback silently inverted the file's
+    documented ordering and nobody noticed for 572 entries.
+    """
+    if not path.exists():
+        return
+    content = path.read_text(encoding="utf-8")
+    idx = content.find(PROGRESS_MARKER)
+    if idx < 0:
+        title, sep, rest = content.partition("\n")
+        content = f"{title}{sep}\n{PROGRESS_MARKER}\n\n{block}\n\n{rest.lstrip(chr(10))}"
+    else:
+        end = idx + len(PROGRESS_MARKER)
+        content = f"{content[:end]}\n\n{block}\n\n{content[end:].lstrip(chr(10))}"
+    path.write_text(content, encoding="utf-8")
+
+
+def append_progress(status: str, kind: str, summary: str, detail: str = "") -> None:
+    if not PROGRESS_FILE.exists():
+        return
+    summary = scrub(summary).replace("\n", " ").strip()[:300]
+    detail = scrub(detail).strip()
+    if not summary:
+        return
+    block = f"## {now_iso()} | {git_branch()}@{git_rev()} | {status} | {kind}\n{summary}"
+    if detail:
+        block += f"\n\n{detail}"
+    insert_newest_first(PROGRESS_FILE, block)
+
+
+def read_file_safe(path: Path, max_lines: int | None = None) -> str:
+    if not path.exists():
+        return f"<missing: {path}>"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception as exc:
+        return f"<unreadable: {path} ({exc})>"
+    if max_lines is not None:
+        lines = text.splitlines()
+        if len(lines) > max_lines:
+            text = "\n".join(lines[:max_lines]) + f"\n... <{len(lines)-max_lines} more lines>"
+    return text

--- a/.claude/hooks/post_tool_use.py
+++ b/.claude/hooks/post_tool_use.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: append a structured PROGRESS entry whenever Claude runs
+Write, Edit, MultiEdit, or a non-trivial Bash command.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _lib import append_progress, emit, read_input, rel  # noqa: E402
+
+
+# Bash commands that are pure observation -- not worth a PROGRESS entry.
+#
+# Matched as a PREFIX, not a substring. The upstream version used `p in lower`,
+# which dropped `uv run pytest && echo done` for containing "echo " while
+# happily logging `cd /repo && rm -rf build`.
+NOISY_PREFIXES = (
+    "ls", "pwd", "cat", "head", "tail", "echo", "which", "command -v",
+    "rg", "grep", "find", "wc", "stat", "du", "df", "tree", "file",
+    "sed -n", "awk", "jq", "basename", "dirname", "realpath",
+    "git status", "git log", "git diff", "git show", "git branch",
+    "git rev-parse", "git check-ignore",
+    "uv tree", "uv pip list", "nvidia-smi",
+    "modal app list", "modal volume ls", "modal secret list",
+)
+
+INTERESTING_TOOLS = {"Write", "Edit", "MultiEdit", "Bash"}
+
+
+def is_noise(first: str) -> bool:
+    s = first.lstrip()
+    return any(s == p or s.startswith(p + " ") for p in NOISY_PREFIXES)
+
+
+def main() -> None:
+    data = read_input()
+    tool = data.get("tool_name", "")
+    if tool not in INTERESTING_TOOLS:
+        return
+
+    inp = data.get("tool_input", {}) or {}
+    resp = data.get("tool_response", {}) or {}
+
+    if tool == "Bash":
+        cmd = (inp.get("command") or "").strip()
+        if not cmd:
+            return
+        first = cmd.splitlines()[0].strip()
+        if is_noise(first):
+            return
+        # Claude's Bash tool_response has no standard `success` key; treat a
+        # present non-zero/interrupted signal as failure, else done.
+        if isinstance(resp, dict):
+            failed = resp.get("interrupted") is True or resp.get("success") is False
+        else:
+            failed = False
+        append_progress(
+            status="fail" if failed else "done",
+            kind="exec",
+            summary=first[:280],
+        )
+        emit({"suppressOutput": True})
+        return
+
+    file_path = inp.get("file_path") or ""
+    if not file_path:
+        return
+
+    if tool == "Write":
+        action = "created"
+    elif tool in {"Edit", "MultiEdit"}:
+        action = "edited"
+    else:
+        return
+
+    append_progress(
+        status="done",
+        kind="edit",
+        summary=f"{action} `{rel(file_path)}`",
+    )
+    emit({"suppressOutput": True})
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass

--- a/.claude/hooks/pre_compact.py
+++ b/.claude/hooks/pre_compact.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""PreCompact hook: snapshot the current PLAN into PROGRESS.md so the upcoming
+context compaction does not lose session state.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _lib import (  # noqa: E402
+    PLAN_FILE,
+    append_progress,
+    emit,
+    read_input,
+)
+
+
+def unchecked_plan_items() -> list[str]:
+    if not PLAN_FILE.exists():
+        return []
+    items: list[str] = []
+    for line in PLAN_FILE.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- [ ]"):
+            items.append(stripped[5:].strip())
+    return items
+
+
+def main() -> None:
+    data = read_input()
+    trigger = data.get("trigger", "auto")
+
+    items = unchecked_plan_items()
+    if items:
+        summary = f"PreCompact ({trigger}): {len(items)} unchecked PLAN items"
+        detail = "Top open items:\n" + "\n".join(f"- {i}" for i in items[:10])
+    else:
+        summary = f"PreCompact ({trigger}): no unchecked PLAN items"
+        detail = ""
+
+    append_progress(
+        status="info",
+        kind="session",
+        summary=summary,
+        detail=detail,
+    )
+
+    emit({"suppressOutput": True})
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass

--- a/.claude/hooks/session_end.py
+++ b/.claude/hooks/session_end.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""SessionEnd hook: write a 'Next steps' block to PROGRESS.md derived from any
+unchecked items in PLAN.md, so the next session resumes from the right place.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _lib import (  # noqa: E402
+    PLAN_FILE,
+    append_progress,
+    emit,
+    read_input,
+)
+
+
+def unchecked() -> list[str]:
+    if not PLAN_FILE.exists():
+        return []
+    items: list[str] = []
+    for line in PLAN_FILE.read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if s.startswith("- [ ]"):
+            items.append(s[5:].strip())
+    return items
+
+
+def main() -> None:
+    data = read_input()
+    reason = data.get("reason", "other")
+
+    items = unchecked()
+    if not items:
+        summary = f"SessionEnd ({reason}): all PLAN items complete"
+        detail = ""
+    else:
+        summary = f"SessionEnd ({reason}): {len(items)} item(s) carried forward"
+        detail = "Next steps:\n" + "\n".join(f"- {i}" for i in items[:8])
+
+    append_progress(
+        status="info",
+        kind="session",
+        summary=summary,
+        detail=detail,
+    )
+
+    emit({"suppressOutput": True})
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass

--- a/.claude/hooks/session_start.py
+++ b/.claude/hooks/session_start.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject the memory files into Claude's context.
+
+Line caps are deliberately tight: this payload is prepended to every session, so
+each file gets only enough to orient, not its full contents.
+
+Deliberately does NOT inject CLAUDE.md or AGENTS.md. Claude Code already loads
+both natively into the cached system prompt; re-injecting them as
+`additionalContext` duplicates the payload uncached on every session start,
+including resume and post-compact. (If a subproject AGENTS.md is ever added --
+e.g. `pipeline/AGENTS.md` -- reconsider, but today there is exactly one and it
+lives at the root.)
+
+It DOES inject two orchestration docs, because they are not in the system prompt
+and nothing else records the Modal/TPU boundary. CONTROL_PLANE.md earns its place
+in every session: it is what stops a Modal fact being written into a TPU surface
+and vice versa. Both are guarded on .exists().
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _lib import (  # noqa: E402
+    PROJECT_DIR,
+    PROGRESS_FILE,
+    PLAN_FILE,
+    VERIFY_FILE,
+    MEMORIES_FILE,
+    ORCHESTRATION_CONTROL_PLANE,
+    ORCHESTRATION_TPU_OPT_SPEC,
+    emit,
+    read_file_safe,
+    read_input,
+    git_branch,
+    git_rev,
+)
+
+
+def verify_inventory() -> str:
+    """List the Stop-hook check ids rather than dumping VERIFY.md.
+
+    VERIFY.md is mostly python heredocs; truncating it at 80 lines would show
+    two of five blocks and waste the budget. The ids are what matters here.
+    """
+    if not VERIFY_FILE.exists():
+        return "<missing: .claude/VERIFY.md>"
+    ids = re.findall(
+        r"^#\s*verify:\s*(\S+)", VERIFY_FILE.read_text(encoding="utf-8"), re.M
+    )
+    if not ids:
+        return "(no checks defined)"
+    return "Stop-hook checks: " + ", ".join(f"`{i}`" for i in ids)
+
+
+def main() -> None:
+    data = read_input()
+    cwd = data.get("cwd") or str(PROJECT_DIR)
+
+    parts: list[str] = []
+    parts.append(
+        f"# Memory System Context\n"
+        f"\nbranch: `{git_branch()}@{git_rev()}`  cwd: `{cwd}`\n"
+    )
+
+    parts.append("\n## PLAN.md (current goal)\n")
+    parts.append(read_file_safe(PLAN_FILE, max_lines=150))
+
+    parts.append("\n## PROGRESS.md (most recent)\n")
+    parts.append(read_file_safe(PROGRESS_FILE, max_lines=60))
+
+    parts.append("\n## VERIFY.md (done-criteria)\n")
+    parts.append(verify_inventory())
+
+    parts.append("\n## memories.md (decisions and gotchas)\n")
+    parts.append(read_file_safe(MEMORIES_FILE, max_lines=150))
+
+    # Guarded: absent orchestration must inject nothing rather than "<missing: ...>".
+    if ORCHESTRATION_CONTROL_PLANE.exists():
+        parts.append("\n## orchestration/CONTROL_PLANE.md (surface ownership)\n")
+        parts.append(read_file_safe(ORCHESTRATION_CONTROL_PLANE, max_lines=100))
+
+    if ORCHESTRATION_TPU_OPT_SPEC.exists():
+        parts.append("\n## orchestration/TPU_OPTIMIZATION_SPEC.md (protected TPU config)\n")
+        parts.append(read_file_safe(ORCHESTRATION_TPU_OPT_SPEC, max_lines=60))
+
+    parts.append(
+        "\n## Quick capture\n"
+        "\nStart a prompt with `#progress <what>`, `#plan <task>`, "
+        "`#decision <what and why>`, or `#verify <bash>` to write straight to "
+        "the matching memory file. See `.claude/MEMORY-SYSTEM.md`.\n"
+    )
+
+    additional_context = "\n".join(parts).strip()
+
+    emit({
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": additional_context,
+        },
+        "suppressOutput": True,
+    })
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass

--- a/.claude/hooks/stop.py
+++ b/.claude/hooks/stop.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Stop hook: when Claude finishes responding, run the VERIFY.md checks in
+non-blocking mode.
+
+Results land in PROGRESS.md; a failure does NOT block the stop by default --
+override with MEMORY_STOP_BLOCK_ON_FAIL=1. Skip entirely with
+MEMORY_STOP_DISABLE_VERIFY=1.
+
+Budget: 12s per block x a cap of 6 blocks = 72s, inside the 90s Stop timeout in
+settings.json. Was 5x15=75s; went to 6x12 when the backend-seam check landed, so
+adding a block did not push the worst case past the ceiling. (Upstream allowed
+20s x 12 = 240s against the same 90s ceiling, so the hook was killed mid-run
+whenever more than four blocks were slow.)
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _lib import (  # noqa: E402
+    PROJECT_DIR,
+    PROGRESS_FILE,
+    VERIFY_FILE,
+    PLAN_FILE,
+    append_progress,
+    emit,
+    read_input,
+)
+
+
+# Only ```bash fences execute. ```sh fences in VERIFY.md are documentation and
+# proposals -- that distinction is what keeps `#verify` quick-capture from
+# injecting a command that then runs after every response.
+CODE_FENCE = re.compile(r"```bash\s*\n(.*?)```", re.DOTALL)
+VERIFY_ID = re.compile(r"^#\s*verify:\s*(\S+)", re.M)
+
+PER_BLOCK_TIMEOUT = 12
+MAX_BLOCKS = 6
+
+
+def extract_commands() -> list[str]:
+    if not VERIFY_FILE.exists():
+        return []
+    text = VERIFY_FILE.read_text(encoding="utf-8")
+    return [m.group(1).strip() for m in CODE_FENCE.finditer(text) if m.group(1).strip()]
+
+
+def block_id(cmd: str) -> str:
+    """Stable handle for a block, from its `# verify: <id>` first line.
+
+    Falls back to the first line, which is what upstream used exclusively --
+    and which is identical across blocks once they all start with the same
+    `cd "${CLAUDE_PROJECT_DIR:-$PWD}"`, making `tick_plan_for` dead code.
+    """
+    m = VERIFY_ID.search(cmd)
+    return m.group(1) if m else cmd.splitlines()[0].strip()[:60]
+
+
+def run_command(cmd: str, timeout: int = PER_BLOCK_TIMEOUT) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(
+            ["bash", "-eo", "pipefail", "-c", cmd],
+            cwd=str(PROJECT_DIR),
+            capture_output=True,
+            timeout=timeout,
+            text=True,
+        )
+        out = (proc.stdout + proc.stderr).strip()
+        return proc.returncode, out[-400:]
+    except subprocess.TimeoutExpired:
+        return 124, f"timeout after {timeout}s"
+    except Exception as exc:
+        return 99, str(exc)[:400]
+
+
+def tick_plan_for(cmd: str) -> None:
+    """Tick any PLAN item tagged `<!-- verify:<id> -->` for this block.
+
+    The tag may sit on a continuation line of a wrapped checklist item, so this
+    walks back from the tag to the nearest preceding `- [ ]`. The original
+    version required the tag and the checkbox on the SAME line and therefore
+    silently ticked nothing for every multi-line item -- which is most of them.
+    """
+    if not PLAN_FILE.exists():
+        return
+    tag = f"<!-- verify:{block_id(cmd)} -->"
+    lines = PLAN_FILE.read_text(encoding="utf-8").splitlines(keepends=True)
+    changed = False
+    for i, line in enumerate(lines):
+        if tag not in line:
+            continue
+        # Walk back to the item this tag belongs to, stopping at a blank line or
+        # a heading so a stray tag cannot tick an unrelated item above it.
+        for j in range(i, -1, -1):
+            stripped = lines[j].strip()
+            if not stripped or stripped.startswith("#"):
+                break
+            if lines[j].lstrip().startswith("- [ ]"):
+                lines[j] = lines[j].replace("- [ ]", "- [x]", 1)
+                changed = True
+                break
+            if lines[j].lstrip().startswith("- [x]"):
+                break  # already ticked
+    if changed:
+        PLAN_FILE.write_text("".join(lines), encoding="utf-8")
+
+
+def last_verify_summary() -> str:
+    """Summary line of the most recent verify entry, for dedupe.
+
+    Upstream logged one identical line 43 times out of 74 verify entries.
+    """
+    try:
+        lines = PROGRESS_FILE.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return ""
+    for i, line in enumerate(lines[:300]):
+        if line.startswith("## ") and line.rstrip().endswith("| verify"):
+            return lines[i + 1].strip() if i + 1 < len(lines) else ""
+    return ""
+
+
+def main() -> None:
+    data = read_input()
+    if data.get("stop_hook_active"):
+        return
+
+    if os.environ.get("MEMORY_STOP_DISABLE_VERIFY") == "1":
+        return
+
+    commands = extract_commands()
+    if not commands:
+        return
+
+    dropped = max(0, len(commands) - MAX_BLOCKS)
+    commands = commands[:MAX_BLOCKS]
+
+    failures: list[tuple[str, int, str]] = []
+    passes: list[str] = []
+    for cmd in commands:
+        rc, out = run_command(cmd)
+        bid = block_id(cmd)
+        if rc == 0:
+            passes.append(bid)
+            tick_plan_for(cmd)
+        else:
+            failures.append((bid, rc, out))
+
+    summary = f"verify: {len(passes)}/{len(commands)} passed on Stop"
+    if failures:
+        summary += f" (first fail: {failures[0][0]})"
+    if dropped:
+        summary += f" [{dropped} block(s) over the {MAX_BLOCKS}-block cap not run]"
+
+    detail_lines = []
+    for bid, rc, out in failures:
+        detail_lines.append(f"FAIL [{rc}] {bid}")
+        if out:
+            detail_lines.append(f"    {out.splitlines()[-1]}")
+    detail = "\n".join(detail_lines)
+
+    # Only log when something changed. A run that repeats the previous result
+    # adds nothing and would dominate the log.
+    if summary != last_verify_summary():
+        append_progress(
+            status="done" if not failures else "fail",
+            kind="verify",
+            summary=summary,
+            detail=detail,
+        )
+
+    if failures and os.environ.get("MEMORY_STOP_BLOCK_ON_FAIL") == "1":
+        emit({
+            "decision": "block",
+            "reason": (
+                f"verify reported {len(failures)} failure(s): "
+                f"{', '.join(f[0] for f in failures)}. "
+                "Fix them before stopping, or unset MEMORY_STOP_BLOCK_ON_FAIL "
+                "to disable this gate."
+            ),
+        })
+        return
+
+    emit({"suppressOutput": True})
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass

--- a/.claude/hooks/user_prompt_submit.py
+++ b/.claude/hooks/user_prompt_submit.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: route '#progress', '#plan', '#decision', '#verify'
+quick-capture prefixes to the right memory file.
+
+Section headings here must match the headings that actually exist in the target
+files -- upstream, `#decision` wrote to `## Architecture decisions` and `#plan`
+to `## Tasks`, neither of which existed, so both silently appended at EOF under
+a stray heading.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _lib import (  # noqa: E402
+    PROGRESS_FILE,
+    PLAN_FILE,
+    VERIFY_FILE,
+    MEMORIES_FILE,
+    emit,
+    git_branch,
+    git_rev,
+    insert_newest_first,
+    now_iso,
+    read_input,
+    scrub,
+)
+
+
+TRIGGERS = {
+    "#progress": ("progress", PROGRESS_FILE),
+    "#plan": ("plan", PLAN_FILE),
+    "#decision": ("decision", MEMORIES_FILE),
+    "#verify": ("verify", VERIFY_FILE),
+}
+
+# Headings the routers target. These must exist in the seeded files.
+PLAN_SECTION = "## Tasks"
+DECISION_SECTION = "## Project decisions"
+VERIFY_SECTION = "## Proposed checks"
+
+
+def main() -> None:
+    data = read_input()
+    prompt = (data.get("prompt") or "").strip()
+    if not prompt.startswith("#"):
+        return
+
+    first_token = prompt.split(None, 1)[0].lower()
+    if first_token not in TRIGGERS:
+        return
+
+    kind, mem_file = TRIGGERS[first_token]
+    body = prompt[len(first_token):].strip()
+    if not body:
+        return
+
+    body = scrub(body)
+    if kind == "progress":
+        block = (
+            f"## {now_iso()} | {git_branch()}@{git_rev()} | info | quick-capture\n"
+            f"{body}"
+        )
+        insert_newest_first(mem_file, block)
+    elif kind == "plan":
+        line = f"- [ ] {body}  <!-- captured {now_iso()} -->\n"
+        _append_under_section(mem_file, PLAN_SECTION, line)
+    elif kind == "decision":
+        ymd = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        block = (
+            f"\n### {ymd}: {body[:80]}\n"
+            f"**Decision:** {body}\n"
+            f"**Captured-from:** quick-capture (`#decision`)\n"
+        )
+        _append_under_section(mem_file, DECISION_SECTION, block)
+    elif kind == "verify":
+        # A `sh` fence, not `bash`: the Stop hook only executes ```bash blocks,
+        # so a captured command is a proposal until someone promotes it by hand.
+        # Quick-capture must not be able to inject a command that then runs
+        # after every response.
+        block = f"\n```sh\n{body}\n```\n"
+        _append_under_section(mem_file, VERIFY_SECTION, block)
+
+    emit({
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": (
+                f"Memory: captured `{kind}` entry to .claude/{mem_file.name}."
+                + (
+                    " It is a ```sh proposal and will NOT run on Stop until"
+                    " promoted to a ```bash fence."
+                    if kind == "verify"
+                    else ""
+                )
+            ),
+        },
+        "systemMessage": f"memory: saved `{kind}` to {mem_file.name}",
+        "suppressOutput": True,
+    })
+
+
+def _append_under_section(path: Path, section_header: str, text: str) -> None:
+    """Insert `text` at the end of the named section.
+
+    The heading is matched as a whole line, not as a substring. A bare
+    `content.find("## Tasks")` also matches the phrase "## Tasks" inside prose
+    or an HTML comment -- PLAN.md's own quick-capture hint mentions the heading
+    by name, and a substring match landed every captured task above the real
+    section.
+    """
+    if not path.exists():
+        return
+    content = path.read_text(encoding="utf-8")
+    m = re.search(rf"^{re.escape(section_header)}[ \t]*$", content, re.M)
+    if m is None:
+        path.write_text(
+            content.rstrip("\n") + f"\n\n{section_header}\n{text}", encoding="utf-8"
+        )
+        return
+    nxt = re.search(r"^## ", content[m.end():], re.M)
+    if nxt is None:
+        path.write_text(content.rstrip("\n") + "\n" + text, encoding="utf-8")
+        return
+    cut = m.end() + nxt.start()
+    path.write_text(content[:cut] + text + content[cut:], encoding="utf-8")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass

--- a/.claude/orchestration/CONTROL_PLANE.md
+++ b/.claude/orchestration/CONTROL_PLANE.md
@@ -1,0 +1,143 @@
+# Orchestration Control Plane
+
+**Version:** v1 (2026-07-25)
+**Adapted from:** `llm-architectures` v1 (shape, dedup rules) + `tinyaya-stage2-scale` v2
+(torch_xla content). Both are sibling repos on the same TRC grant and GCP project.
+**Scope:** repo-level. Covers **both** compute paths — Modal/GPU and TPU/torch_xla.
+**Purpose:** one map of skills, agents, hooks, memory files, scripts, and external
+surfaces — so every fact is written once.
+
+## 0. Two compute paths
+
+Tiny Aya Vision has two ways to run heavy work. They are not competitors, and one is not
+replacing the other.
+
+| Path | Status | Entry | Owns |
+|---|---|---|---|
+| **Modal / GPU** (DDP + CUDA) | **Authoritative.** Everything published came from here. | `scripts/modal_*.py`, `torchrun` | Every number in `docs/*.md`, every checkpoint, every eval, CI |
+| **TPU / torch_xla** (SPMD) | **Experimental.** No training step has run. | `scripts/tpu/*.sh` | Slice provisioning, run supervision, the throughput/HBM envelope |
+
+The boundary is a single rule: **no TPU number may be written into a `docs/*.md` results
+table until the same `pipeline/train_*.py` produces it on both backends.** Until the
+backend seam lands (`SPEC.md` §9) the TPU path cannot produce a comparable number even in
+principle, and pretending otherwise is how two sets of books start.
+
+## 1. Entry points
+
+| Intent | Entry point | Supporting files |
+|---|---|---|
+| Load state before non-trivial work | SessionStart hook (automatic) or `/recall` | `PLAN.md`, `PROGRESS.md`, `VERIFY.md`, `memories.md`, this file |
+| Run or supervise a TPU stage | `tpu-orchestrate` skill | `SPEC.md`, `playbook/*`, `tpu-watchdog`, `tpu-diagnoser` |
+| Tune TPU throughput | `tpu-orchestrate` in optimization mode | `TPU_OPTIMIZATION_SPEC.md`, `playbook/optimization-experiment-matrix.md` |
+| Push code to a live slice | `tpu-redeploy` skill | `scripts/tpu/deploy_tarball.sh` |
+| Classify a TPU failure | `tpu-diagnoser` agent | `playbook/tier-definitions.md` |
+| Run training / eval / tests **today** | `modal run scripts/modal_<name>.py` | `CLAUDE.md` "Commands" — **not** this folder |
+| Record goal / phase changes | `/plan` | `.claude/PLAN.md` |
+| Record events | PostToolUse hook (automatic) or `/progress` | `.claude/PROGRESS.md` |
+| Record a durable decision | `/remember` or `#decision …` | `.claude/memories.md` |
+| Prove done | `/verify` or Stop hook | `.claude/VERIFY.md` |
+
+`tpu-orchestrate` is the master run-control skill **for TPU work only**. It has no
+authority over the Modal path, which is driven directly from `CLAUDE.md`.
+
+## 2. Source-of-truth boundaries
+
+| Surface | Owns | Does NOT own |
+|---|---|---|
+| `CLAUDE.md` | Repo architecture, commands, conventions, **which path is authoritative** | Run state, operational history, TPU procedure |
+| `AGENTS.md` | Modal SDK usage — a vendor cheat-sheet | Anything about this project |
+| `.claude/PLAN.md` | Current goal + phase checklist | Run history, raw logs |
+| `.claude/PROGRESS.md` | Append-only event log | Durable rationale |
+| `.claude/memories.md` | Durable decisions + gotchas | Step-by-step task lists |
+| `.claude/VERIFY.md` | Commands that prove the repo is sane | Experiment hypotheses |
+| `.claude/orchestration/CONTROL_PLANE.md` | This map: which surface owns which fact | Any fact itself |
+| `.claude/orchestration/SPEC.md` | TPU run loop + recovery policy | Detection signatures; optimization phases |
+| `.claude/orchestration/TPU_OPTIMIZATION_SPEC.md` | Protected TPU config + promotion gates | Failure recovery |
+| `.claude/agents/tpu-diagnoser.md` | **The diagnosis table** (canonical) | Recovery policy — that is `SPEC.md` |
+| `.claude/orchestration/playbook/*` | Tier policy, event meanings, metric names, baselines | Raw runtime data |
+| `scripts/modal_*.py` | **Every published result**: training, eval, tests, checkpoints | TPU provisioning |
+| `scripts/tpu/*.sh` | Slice provisioning, code delivery, run supervision | What the model computes |
+| `pipeline/train_*.py` | The training step, for **both** paths | Which accelerator runs it — that is `src/backend/`, once it exists |
+| `config/` (Hydra YAML + dataclasses) | Hyperparameters, token arithmetic | Anything topology-shaped (mesh, chips, hosts) |
+| `docs/tpu/tpu-trc-allocation.md` | TRC quota + zone grants | Live capacity, zone selection |
+| `docs/tpu/tpu-capacity-log.md` | Observed queue times + **the fallback tree** | The grant itself |
+| `docs/tpu/tpu-runbook.md` | The operator command sequence | Why any of it is shaped that way |
+| `docs/baselines.md`, `docs/instruction_tuning_results.md` | Published numbers — **Modal/GPU only** | TPU throughput or HBM |
+| W&B `tayavision-instruct-sweep`, `tayavision-multilingual` | GPU/Modal metrics | TPU metrics |
+| W&B `tayavision-tpu` | TPU metrics, step time, HBM envelope | Any published quality number |
+| Modal volumes `tayavision-{data,models}`, `multilingual-data` | Datasets + GPU checkpoints | Anything TPU-side |
+| `gs://tayavision-eu` | TPU checkpoints + code tarballs | Modal volume contents |
+| `/tmp/*.log` (VM + workstation) | Ephemeral runtime detail | Anything durable |
+
+Rule: **write a fact once, at the most specific durable layer, then link to it.**
+
+Two places where this is load-bearing rather than decorative:
+
+- The diagnosis table lives in `tpu-diagnoser.md` **only**. `playbook/diagnosis-table.md`
+  is a pointer, not a second copy. `tinyaya-stage2-scale` carried it in five places and
+  they drifted.
+- The zone fallback tree lives in `docs/tpu/tpu-capacity-log.md` **only**. The allocation
+  doc points at it. A fallback tree that drifts from observed capacity sends you to a
+  zone that is blocked or costs egress.
+
+## 3. Pipeline stages
+
+Every stage runs through the same deploy/supervise machinery, selected by
+`TAYAVISION_ENTRYPOINT`. A new stage plugs in by adding a row here, not by touching
+`scripts/tpu/`.
+
+| Stage | `TAYAVISION_ENTRYPOINT` | Inputs | Produces | TPU today? |
+|---|---|---|---|---|
+| Control-plane smoke | `scripts/tpu/tpu_smoke.py` | none | device count, mesh, HBM, compile counters | **yes** |
+| Backbone smoke | `scripts/tpu/tpu_smoke.py --load-backbone` | `HF_TOKEN` | materialized model + real HBM peak | **yes** |
+| Alignment (Phase 1) | `pipeline/train_alignment.py` | LLaVA-Pretrain 558K | projector weights | **no** — DDP+CUDA |
+| Instruct (Phase 2) | `pipeline/train_instruct.py` | LLaVA-mix665k + Phase 1 ckpt | projector + LoRA r=256 | **no** — DDP+CUDA |
+| Multilingual (Phase 2') | `pipeline/train_multilingual.py` | 9-source, 67-language mix | multilingual checkpoint | **no** — DDP+CUDA |
+| Eval | `evaluation/run_eval.py` | a checkpoint | lm-eval scores | **no** — stays on Modal |
+| Weight merge | `scripts/merge_weights.py` | 2 checkpoints | LERP'd backbone | **no** — CPU, stays on Modal |
+
+The three "no — DDP+CUDA" rows are the whole of the remaining work. See `SPEC.md` §9.
+
+## 4. Layers (who survives what)
+
+| Layer | Dies when | Survives |
+|---|---|---|
+| VM tmux `train` (per worker) | node preempted/rebooted | workstation off, Claude session ends |
+| Workstation tmux `qrwatch-tayavision` | workstation off | Claude session ends, node preemption |
+| Boot self-heal (QR metadata) | QR deleted | node reboot, preemption |
+| Claude session | anything | nothing — **never** owns a long loop |
+
+The rule this encodes: **a loop that must outlive the conversation never runs inside the
+conversation.** Session-bound monitors died three times on `llm-architectures` before
+this was enforced.
+
+The workstation session name is suffixed because the same workstation runs a plain
+`qrwatch` for `llm-architectures`. `tmux new -s qrwatch` against an existing session
+attaches to the wrong one, which leaves this project's queued resource silently
+unwatched — precisely the failure this layer exists to prevent.
+
+## 5. Agents
+
+| Agent | Mode | Responsibility |
+|---|---|---|
+| `tpu-watchdog` | read-only | Report live run state across every worker |
+| `tpu-diagnoser` | read-only | Classify a failure signature → tier + action |
+
+Agents never edit files, restart processes, or touch queued resources. They report; the
+orchestrator acts.
+
+## 6. External surfaces
+
+- TPU metrics: `https://wandb.ai/cataluna84/tayavision-tpu` — deliberately separate from
+  the two GPU projects so bring-up noise never lands in a results project.
+- GPU/Modal metrics: `tayavision-instruct-sweep`, `tayavision-multilingual`.
+- Push events: `https://ntfy.sh/$NTFY_TOPIC` (topic in the gitignored `.env`; see
+  `.env.example`). `notify()` is a no-op when unset, so call sites are unconditional.
+- TPU checkpoints + code tarballs: **`gs://tayavision-eu` (europe-west4), one bucket.**
+  Only the three `europe-west4-*` profiles are co-located; anything else pays egress on
+  every write. See `docs/tpu/tpu-trc-allocation.md` "Bucket co-location".
+- Modal: apps `tayavision-train-alignment`, `tayavision-eval`, `tayavision-pytest`;
+  volumes `tayavision-data`, `tayavision-models`, `multilingual-data`.
+- Code delivery to TPU: GCS tarball only — **never** a git clone. The tarball includes
+  the gitignored `.env`, which is how `HF_TOKEN` (the gated `CohereLabs/tiny-aya-*`
+  repos), `WANDB_API_KEY`, and `NTFY_TOPIC` reach the VM.

--- a/.claude/orchestration/README.md
+++ b/.claude/orchestration/README.md
@@ -1,0 +1,119 @@
+# `.claude/orchestration/`
+
+Source-of-truth design artifacts for TPU run control on Tiny Aya Vision. Documents live
+here; implementations live in their natural homes and are indexed below.
+
+**Status (2026-07-25):** imported and adapted. **No Tiny Aya Vision TPU run has
+happened.** `pipeline/train_*.py` is DDP + CUDA and does not run under torch_xla — see
+`SPEC.md` §9 before launching anything. Everything here describes provisioning and
+supervision, which is real and testable today via `scripts/tpu/tpu_smoke.py`.
+
+## Layout
+
+```
+orchestration/
+├── README.md                   this file — index + provenance
+├── CONTROL_PLANE.md            who owns which fact; BOTH compute paths
+├── SPEC.md                     the run loop, recovery policy, invariants, §9 gap
+├── TPU_OPTIMIZATION_SPEC.md    protected config, 6 gates, 9-phase program
+├── playbook/
+│   ├── tier-definitions.md              T0-T4 ladder + escalation triggers
+│   ├── diagnosis-table.md               POINTER to agents/tpu-diagnoser.md
+│   ├── event-taxonomy.md                ntfy events + design rules
+│   ├── perf-metrics-schema.md           W&B field names + comparability invariants
+│   ├── optimization-experiment-matrix.md  12 candidates + the run ladder
+│   └── baseline-v6e8-siglip-cohere2.md  protected numbers (all TBD today)
+└── diagrams/
+    ├── 01-architecture.mmd     layers and what each survives
+    ├── 02-state-machine.mmd    DEPLOY/WATCH/CLASSIFY/RECOVER
+    ├── 03-memory-lifecycle.mmd ephemeral runtime data → durable knowledge
+    └── render.sh               *.mmd → svg/ + png/
+```
+
+## Implementation files (NOT here)
+
+| Artifact | Location | Purpose |
+|---|---|---|
+| Shared helpers | `scripts/tpu/_lib.sh` | `load_env_file`, `notify`, `make_code_tarball` |
+| One-time bootstrap | `scripts/tpu/setup_gcp.sh` | APIs, `gs://tayavision-eu`, IAM |
+| QR submit | `scripts/tpu/launch_qr.sh`, `launch_spot.sh` | Provision a slice; profile → zone/accelerator |
+| Boot | `scripts/tpu/startup_script.sh` | Fetch tarball, install deps, resolve `_XLAC.so`, launch |
+| Launcher | `scripts/tpu/train_launcher.sh` | Emits the markers every watcher greps |
+| Deploy (T2) | `scripts/tpu/deploy_tarball.sh` | tar → GCS → all workers → relaunch |
+| QR babysitter (T3) | `scripts/tpu/qr_watch.sh` | Recycle on preemption, gated on `gs://` checkpoints |
+| Daily ops | `scripts/tpu/ops.sh` | `preflight`, `status`, `tail-logs`, `attach`, `ssh`, `delete` |
+| Smoke entrypoint | `scripts/tpu/tpu_smoke.py` | The default `TAYAVISION_ENTRYPOINT` |
+| Skill | `.claude/skills/tpu-orchestrate/SKILL.md` | Run-control entry point |
+| Skill | `.claude/skills/tpu-redeploy/SKILL.md` | The T2 procedure |
+| Agent | `.claude/agents/tpu-watchdog.md` | Read-only live state |
+| Agent | `.claude/agents/tpu-diagnoser.md` | **Canonical diagnosis table** |
+| Grant + capacity | `docs/tpu/*.md` | TRC quota, observed capacity, operator runbook |
+
+## Provenance
+
+Merged from two sibling repos on the same TRC grant and GCP project.
+
+**Shape from `llm-architectures`** (pure JAX, 2026-07-20) — a deduplicated refactor of
+the tinyaya original: the DEPLOY/WATCH/CLASSIFY/RECOVER loop, the T0-T4 ladder,
+non-blocking ntfy events, the surface-ownership table, and the discipline of one
+canonical diagnosis table. Its `playbook/diagnosis-table.md` is a pointer, not a copy,
+and that choice is preserved here.
+
+**torch_xla content from `tinyaya-stage2-scale`** (2026-05-13) — `TPU_OPTIMIZATION_SPEC.md`
+and `optimization-experiment-matrix.md`, which `llm-architectures` dropped as having no
+JAX analogue. They come back because this project is PyTorch, and because that project
+runs **the same Cohere2 backbone with the same 36 decoder layers** — its FSDPv2
+reduce-scatter NaN is a hazard this repo inherits rather than merely resembles.
+
+### Divergences from both sources
+
+1. **T3 is conditionally automatic.** tinyaya locked T3 to "always escalate";
+   `llm-architectures` inverted it to unconditional auto-recycle. Here `qr_watch.sh`
+   auto-recycles **only when `SAVE_CKPT_DIR` is a `gs://` URI**, and otherwise degrades
+   to notify-only. Recycling without durable checkpoints restarts from step 0 and re-pays
+   ~14 min of XLA compile, twenty times, silently.
+2. **The compile threshold is 20 minutes, not 10.** `llm-architectures`'s "no step line
+   for 10 min = hang" is a JAX rule. torch_xla on v6e SPMD takes ~14 min to compile on a
+   cold boot, so that rule would fire on every single launch here. Classification uses
+   the `met.metrics_report()` compile-cause counter, not elapsed time.
+3. **No sweep layer.** `llm-architectures` has a fifth layer — `sweep` tmux running an
+   ordered runs-file — plus `vm_coordinator`, `race_provision`, and a supervisor VM. None
+   are ported: there is nothing to sweep until `SPEC.md` §9 is closed.
+4. **`replicated` is the default strategy, not FSDPv2.** Phase 1 trains ~11.5M of ~3.75B
+   params against 31.25 GiB/chip. Neither source could default this way; both were memory
+   constrained.
+5. **Config travels as one Hydra override string.** nanoGPT reads ~15 env overrides;
+   tinyaya edits YAML. This repo is Hydra, so `TAYAVISION_HYDRA_OVERRIDES` is appended
+   verbatim to the launch line rather than inventing a parallel env surface.
+6. **The control plane covers two compute paths.** Neither source had to say which of
+   Modal and TPU owns a given fact. `CONTROL_PLANE.md` §0 and §2 do.
+7. **One bucket.** `gs://tayavision-eu`. Both sources kept region-paired siblings; here
+   every non-EU profile is an explicit egress decision, and the zone fallback tree in
+   `docs/tpu/tpu-capacity-log.md` was reordered to match.
+
+## Read order
+
+1. `CONTROL_PLANE.md` — surface ownership, and which compute path is authoritative
+2. `SPEC.md` — the run loop; **§9 first if you are about to launch something**
+3. `playbook/tier-definitions.md` — what to do at each tier
+4. `.claude/agents/tpu-diagnoser.md` — signature → tier
+5. `TPU_OPTIMIZATION_SPEC.md` + `playbook/optimization-experiment-matrix.md` — only once
+   a run is stable
+6. `docs/tpu/tpu-runbook.md` — the actual commands
+
+## Rendering diagrams
+
+```bash
+bash .claude/orchestration/diagrams/render.sh
+```
+
+Requires `mmdc` (`npm i -g @mermaid-js/mermaid-cli`), falling back to `npx`. **Neither is
+installed on this workstation**, so rendering is currently unavailable — the `.mmd`
+sources are the checked-in artifact and `svg/`/`png/` are gitignored. GitHub renders
+mermaid natively, so the sources are readable without local tooling.
+
+## Versioning
+
+An edit that changes behaviour bumps the version banner in `SPEC.md` and updates the
+affected diagram **in the same commit**. A spec that disagrees with its diagram is how
+five diagnosis tables happened.

--- a/.claude/orchestration/SPEC.md
+++ b/.claude/orchestration/SPEC.md
@@ -1,0 +1,237 @@
+# Tiny Aya Vision TPU Run Control — SPEC
+
+**Version:** v1 (2026-07-25)
+**Stack:** torch_xla SPMD (PyTorch), *not* JAX. Adapted from `llm-architectures` v1 (the
+loop, the ladder, the dedup rules) and `tinyaya-stage2-scale` v4 (the torch_xla content,
+same Cohere2 backbone).
+**Status:** control plane designed and testable; **no training entrypoint runs on TPU
+yet** — read §9 before launching anything.
+**Topology:** default `v6e-8` = 1 host × 8 chips, single Python process, SPMD. Multi-host
+profiles exist in `launch_spot.sh` but are blocked on `IN_USE_ADDRESSES` — see
+`docs/tpu/tpu-capacity-log.md` §7.1.
+
+Read `CONTROL_PLANE.md` first for surface ownership.
+
+## 1. Goal
+
+Drive a TPU stage to completion with **bounded autonomous recovery**, on spot capacity
+that will be preempted mid-run, without a human in the loop and without a Claude session
+being load-bearing.
+
+## 2. Decisions locked
+
+| Decision | Value | Why |
+|---|---|---|
+| Stack | torch_xla SPMD | Proven on `tinyaya-stage2-scale` against the same Cohere2 + LoRA backbone. A JAX rewrite of an HF `PreTrainedModel` is not a port, it is a second model. |
+| Orchestration home | workstation tmux `qrwatch-tayavision` | Claude sessions die; three did on the sibling repo. Suffixed because that repo's `qrwatch` runs on the same workstation. |
+| Training home | VM tmux `train`, every worker | Multi-host PJRT rendezvous needs every host |
+| Code delivery | GCS tarball incl. `.env` | `CohereLabs/tiny-aya-*` is **gated**; without `HF_TOKEN` on the VM the run cannot start. A git clone can never ship it. |
+| Config transport | one Hydra override string | This repo is Hydra, not a wall of env vars. `TAYAVISION_HYDRA_OVERRIDES` is appended verbatim to the launch line. |
+| Bucket | **one**, `gs://tayavision-eu` | User decision. Makes the three `europe-west4-*` profiles co-located and everything else an explicit egress choice. |
+| Default `TPU_STRATEGY` | `replicated` | Phase 1 trains ~11.5M of ~3.75B params; the model is ~7.5 GB bf16 against 31.25 GiB/chip. FSDPv2 buys nothing here and costs the reduce-scatter hazard in §7. |
+| T3 (node lost) | **auto-recycle, gated on `gs://` checkpoints** | See §5 — a considered split between the two source policies |
+| Check-ins | **push-only** (ntfy) + 2h heartbeat | Nothing blocks on a human |
+| Resume | `TAYAVISION_RESUME=auto` | Preemption reboot self-heals |
+| Iteration cap | `MAX_RESUBMITS=20`, then stop | Anti-flap without a hard wall-clock cap |
+| Modal | **unchanged and authoritative** | Nothing here replaces it. See `CONTROL_PLANE.md` §0. |
+
+## 3. Architecture (4 layers)
+
+See `diagrams/01-architecture.mmd`.
+
+```
+Claude session      reads logs, decides, edits code        (disposable)
+      |
+Workstation tmux    qrwatch-tayavision (QR lifecycle)      (survives Claude)
+      |
+QR metadata         tarball URI, entrypoint, resume=auto,
+                    hydra overrides, W&B identity          (survives reboot)
+      |
+VM tmux `train`     the actual process, x N workers        (survives workstation)
+      |
+GCS + W&B + ntfy    checkpoints, metrics, events           (survives everything)
+```
+
+`llm-architectures` has a fifth layer, a `sweep` tmux running an ordered runs-file. It is
+deliberately not ported: there is nothing to sweep until §9 is closed.
+
+## 4. The run loop
+
+See `diagrams/02-state-machine.mmd`.
+
+```
+DEPLOY -> WATCH -> [ok]           -> WATCH
+                -> [exit clean]   -> DONE
+                -> [exit dirty]   -> CLASSIFY -> RECOVER -> DEPLOY
+                -> [node gone]    -> qr_watch recycles -> boot self-heal
+                -> [budget spent] -> STOP + notify
+```
+
+**DEPLOY** — `deploy_tarball.sh` tars the working tree (incl. `.env`), uploads to GCS,
+pulls on `--worker=all`, and relaunches VM tmux `train` everywhere via
+`train_launcher.sh`. Each deploy bakes a unique `TAYAVISION_RUN_TAG` into the launch line.
+
+**WATCH** — poll worker 0's `/tmp/train.log`, scoped to the segment *after* this run's
+`RUN_TAG`. Never match a stale segment from an earlier deploy or boot; a 7-hour-old
+segment once triggered a spurious abort on the sibling repo.
+
+Completion detection has two independent queries, and this is load-bearing:
+
+- rare status markers (`exited with status`, `Traceback`, `DEADLINE_EXCEEDED`,
+  `RESOURCE_EXHAUSTED`, `nan`) — take the **tail**
+- the repeating per-step line — fetched separately, **tail -1**
+
+Piping both through one `head -N` truncates the status marker behind N repeats of the
+noisy line and the run looks hung forever. That exact bug hid a completed 1000-step run
+for an hour, and it is already recorded in this repo's `memories.md`.
+
+**Compile is not a hang here.** On torch_xla the persistent XLA cache has
+nondeterministic keys on v6e SPMD and effectively never hits: **~14 min of recompile on
+every cold boot is normal** (`docs/tpu/tpu-capacity-log.md` §8). `llm-architectures`'s
+"no step line for 10 min = hang" rule is a JAX rule and produces a false positive on
+every single boot here. The threshold is **20 min**, and the discriminator is
+`met.metrics_report()` compile-cause counters, not elapsed time.
+
+**CLASSIFY** — match the log against the canonical table in
+`.claude/agents/tpu-diagnoser.md`; it returns a tier.
+
+**RECOVER** — act per `playbook/tier-definitions.md`.
+
+## 5. Preemption and T3 (a split decision)
+
+The two source repos disagree. `tinyaya-stage2-scale` locked T3 to "always escalate,
+never auto-recreate the QR". `llm-architectures` inverted it and auto-recycles, on the
+grounds that TRC quota is free, preemption is routine (~25 in one day on v6e), and
+overnight runs must survive.
+
+**This repo takes the auto-recycle policy with one brake neither source has.**
+
+`qr_watch.sh` polls the queued resource every 300s and, on `SUSPENDING` / `SUSPENDED` /
+`FAILED`:
+
+1. captures `describe` JSON forensics,
+2. checks for a quota-class abort (no point resubmitting into a wall),
+3. **checks that `SAVE_CKPT_DIR` starts with `gs://`** — see below,
+4. deletes the QR,
+5. resubmits the identical `launch_spot.sh` env file,
+6. pushes an ntfy event.
+
+Bounded by `MAX_RESUBMITS=20` plus a cooldown. If the QR is absent entirely it exits
+rather than competing with a human — **one resubmitter per QR, ever.**
+
+**The `gs://` gate.** A recycled node whose checkpoints went to node-local disk resumes
+from **step 0** — and then pays a cold-boot XLA recompile to redo work it already did,
+twenty times, silently. Auto-recycle without durable checkpoints is not self-healing, it
+is a capacity incinerator. So when `SAVE_CKPT_DIR` is not a `gs://` URI, `qr_watch.sh`
+degrades to **notify-only (T4)** and says so in the push event.
+
+> **Implemented 2026-07-26, verified on the v6e-16.** This paragraph used to describe the
+> gate as the *only* protection, because `save_checkpoint` genuinely did write node-local
+> and `SAVE_CKPT_DIR` reached no Python at all. Both halves now exist and were verified by
+> deleting `/models/<run_id>` on all four hosts and resuming from the bucket alone:
+>
+> - `save_checkpoint` mirrors every write to `<SAVE_CKPT_DIR>/<run_id>/`.
+> - The resume path calls `fetch_checkpoint_from_gcs` on **every rank** before concluding
+>   there is nothing to resume.
+> - `TAYAVISION_RESUME` is read by `resolve_resume_run_id()`; `auto` resolves to the run
+>   with the most recently mirrored checkpoint and rejoins the same W&B run.
+>
+> The gate still matters — `auto` has nothing to find without a `gs://` root — but it is
+> no longer the only thing standing between a recycle and lost work.
+
+Boot self-heal closes the loop when the gate passes: QR metadata carries the tarball URI,
+`TAYAVISION_ENTRYPOINT`, `TAYAVISION_HYDRA_OVERRIDES`, `TAYAVISION_RESUME=auto`, and the
+W&B run identity — so a recycled node re-fetches code, resumes from the latest GCS
+checkpoint, and keeps logging to the *same* W&B run with no human action.
+
+## 6. Notifications
+
+Nothing blocks on a human. Events push to `https://ntfy.sh/$NTFY_TOPIC` and a 2-hour
+heartbeat proves the watcher is alive — a silent watcher is indistinguishable from a dead
+one. See `playbook/event-taxonomy.md`.
+
+`notify()` is a no-op when `NTFY_TOPIC` is unset, so a first run with no `.env` works; it
+is just deaf. Run one test event end to end before trusting the pipe: this repo's
+`memories.md` already records a full day of alerts lost to a `.env` with no trailing
+newline.
+
+## 7. Invariants (do not break)
+
+- **196 image tokens per image** on the SigLIP path. `config-contracts` in
+  `.claude/VERIFY.md` enforces the arithmetic; XLA enforces it harder, because a variable
+  token count means a new HLO program per shape.
+- **Never wrap `Cohere2DecoderLayer` in an FSDPv2 auto-wrap policy.** 36 per-layer wraps
+  produce 36 bf16 reduce-scatters and hit pytorch/xla #8591 / #8778: NaN loss at step
+  ~24-130. FSDPv2 has no `fp32_reduce_scatter` (only FSDPv1 does, #3588 / #8056). Use one
+  outer reduce-scatter at the composite level. Observed on `tinyaya-stage2-scale` with
+  **this same backbone and the same 36 layers**; assume it applies until disproved.
+- **The wrap policy matches on `type(module).__name__`.** A wrong class-name string wraps
+  nothing and looks like it worked. Verify the name against the installed `transformers`
+  before trusting any FSDPv2 run.
+- **SPMD is one process.** `DistributedSampler` must be OFF; a single process holding a
+  1/N sampler shard trains on 1/N of the dataset and never says so.
+- **Deploys ship the working tree as a GCS tarball incl. `.env`.** Never clone.
+- **One resubmitter per QR** — `qr_watch` or a human, never both.
+- **Long loops live in tmux**, never in a Claude session.
+- **No TPU number enters a `docs/*.md` results table** until the same
+  `pipeline/train_*.py` runs on both backends.
+
+## 8. Known-good numbers
+
+**There are none.** `playbook/baseline-v6e8-siglip-cohere2.md` is a template with every
+cell marked TBD, plus one clearly-labelled non-authoritative envelope inherited from a
+*different model* on the same backbone family. Fill it from the first real run; do not
+fill it from the sibling repos.
+
+## 9. What does not work yet
+
+`pipeline/train_alignment.py`, `train_instruct.py`, and `train_multilingual.py` are DDP +
+CUDA and **cannot run on TPU today**. In `train_alignment.py` alone:
+`torch.autocast("cuda", ...)`, `torch.device(f"cuda:{local_rank}")`,
+`torch.device("cuda" if torch.cuda.is_available() ...)`, `torch.cuda.manual_seed_all`,
+`DistributedDataParallel`, and `DistributedSampler`.
+
+Everything in this folder and in `scripts/tpu/` is therefore **provisioning and
+supervision**, which is genuinely useful and genuinely testable on its own:
+
+- provision a TRC slice by profile, on spot, with QR-metadata self-heal;
+- deliver the working tree (incl. `.env`, and therefore `HF_TOKEN`) to every worker with
+  no git clone;
+- install `uv` + `torch_xla` and resolve the `libpython3.12.so.1.0` / `_XLAC.so` link;
+- launch in tmux `train` with the exact log markers every watcher matches;
+- watch, classify, redeploy, recycle the QR, and push events.
+
+`TAYAVISION_ENTRYPOINT` defaults to `scripts/tpu/tpu_smoke.py`, which exercises every one
+of those layers end to end and proves libtpu/mesh/HBM on real silicon — without
+pretending training works. `--load-backbone` extends it to download the gated repos and
+materialize the real model, which proves the `HF_TOKEN` path and the memory envelope: the
+two things most likely to be wrong.
+
+**The ladder:** `tpu_smoke.py` → `tpu_smoke.py --load-backbone` → `train_alignment.py`.
+
+### The seam that closes it
+
+Mirroring `tinyaya-stage2-scale`'s proven structure:
+
+- New `src/backend/`: `base.py` (ABC — `device()`, `wrap_model()`, `optimizer_step()`,
+  `sync()`, `memory_info()`, `is_main()`, `autocast()`), `gpu_backend.py` (today's
+  DDP+CUDA extracted **verbatim**, so the Modal path stays byte-equivalent), and
+  `tpu_backend.py` — the **only** module allowed a module-level `import torch_xla`.
+- `scripts/ci/check_backend_seam.sh` greps `^(import torch_xla|from torch_xla)` under
+  `src/`, `models/`, `pipeline/`, `config/` and fails if one leaks. A module-level import
+  drags `libtpu` into the graph and breaks every CPU/GPU run and the 129-test suite.
+  `models/__init__.py` matters most: it registers HF Auto classes at import time and is
+  imported by every eval script.
+- Lazy in-function imports on TPU-only paths stay legal; the check flags column-0 imports
+  only.
+- **The subtle call-site change**: SPMD is a single process, so `DistributedSampler` must
+  be off and the loader wrapped in `MpDeviceLoader`. Leaving `DistributedSampler` on
+  under SPMD silently trains on 1/N of the dataset and looks completely healthy.
+- When `src/backend/` lands, `check_backend_seam.sh` becomes a `# verify: backend-seam`
+  block. **That** is the moment to raise `MAX_BLOCKS` to 6 in `stop.py` and drop
+  `PER_BLOCK_TIMEOUT` to 12 (6 × 12 = 72s, still inside the 90s hook timeout). Not before
+  — a sixth block today would be silently dropped.
+
+Anything that reads this file and then edits `pipeline/train_*.py` to "just add TPU
+support" inline is about to break the Modal path for everyone. The seam exists so that
+does not happen.

--- a/.claude/orchestration/TPU_OPTIMIZATION_SPEC.md
+++ b/.claude/orchestration/TPU_OPTIMIZATION_SPEC.md
@@ -1,0 +1,169 @@
+# TPU Optimization Spec — Tiny Aya Vision (torch_xla)
+
+**Version:** v1 (2026-07-25)
+**Ported from:** `tinyaya-stage2-scale` v2. `llm-architectures` deliberately dropped this
+file as "torch_xla-specific with no analogue in pure JAX" — which was correct there and
+is exactly why it comes back here.
+**Owns:** the protected TPU config, the promotion gates, and the phase program.
+**Does not own:** failure recovery (`SPEC.md`), signatures (`agents/tpu-diagnoser.md`),
+or the candidate list (`playbook/optimization-experiment-matrix.md`).
+
+> **Nothing in this file has been measured on Tiny Aya Vision.** The protected config is
+> a *starting position* derived from a sibling project on the same backbone, not a
+> validated baseline. Phase 0 exists to replace assumption with measurement.
+
+## 1. Goal
+
+Get a training step onto TPU that is **correct first, then fast**. On XLA those are not
+the same problem and the order matters: a config that is fast because it silently
+recompiles per batch, or that fits because it trains on 1/N of the data, will look great
+on a dashboard.
+
+## 2. Protected config
+
+The starting position. Changing any line requires a candidate row in the experiment
+matrix and a passed gate.
+
+```yaml
+# Sharding
+tpu_strategy: replicated        # NOT fsdpv2 -- see §4 and SPEC.md §7
+                                # Phase 1 trains ~11.5M of ~3.75B params;
+                                # ~7.5 GB bf16 fits 31.25 GiB/chip comfortably.
+
+# Precision + memory
+precision: bfloat16
+xla_grad_checkpoint: true       # conservative default; opt-4-nockpt tests removing it
+hbm_ceiling_gib: 29             # of 31.25 usable on v6e
+
+# Compilation
+use_scan_layers: false          # LoRA on layers 18-35 only => heterogeneous layers
+                                # => scan's _ensure_same_structure will fail. Probe only.
+compile_warmup_steps: 0         # opt-2-warmup tests 1
+persistent_xla_cache: false     # nondeterministic keys on v6e SPMD; never warm-hits,
+                                # and costs the UNIMPLEMENTED deserialize failure
+
+# Vision
+vision_encoder: siglip          # fixed 196 tokens/image.
+                                # MoonViT is variable-token => a new HLO per shape.
+image_tokens: 196               # invariant, enforced by VERIFY config-contracts
+
+# Data
+distributed_sampler: false      # SPMD is ONE process. Leaving this on trains
+                                # on 1/N of the dataset and reports nothing wrong.
+log_every: 1                    # opt-1-log25 tests raising it
+```
+
+## 3. Research basis
+
+Stack-level findings, not model-level. These carry across projects because they are
+properties of torch_xla.
+
+| Finding | Consequence here |
+|---|---|
+| XProf `xp.Trace()` labels are the only way to attribute step time on XLA | Phase 0 instruments seven labels before any tuning decision |
+| `.item()` / `.cpu()` force a device sync and break the lazy graph | `models/tiny_aya_vision.py` calls `.item()` on the image-token count every forward — see `opt-0-metrics` |
+| `MPDeviceLoader` overlaps host input with device compute | `opt-5-mpdl`; only worth it once `host/input_gap_ms` proves the pipeline starves the device |
+| FSDPv2 SPMD is the right memory path at scale, but `scan_layers` requires homogeneous **and pure** layers | Both are Phase 7 probes here, not defaults |
+| Dynamic-shape ops (`nonzero`, boolean masking) either fall back to CPU or recompile per shape | The single biggest VLM-specific risk — `opt-6-nonzero` |
+
+## 4. The inherited NaN, and why `replicated` is the default
+
+`tinyaya-stage2-scale`, running **the same Cohere2 backbone with the same 36 decoder
+layers**, hit NaN loss at step 24-130 under FSDPv2. Root cause: the auto-wrap policy
+wrapped each `Cohere2DecoderLayer`, producing 36 separate bf16 reduce-scatters.
+FSDPv2 has no `fp32_reduce_scatter` (FSDPv1 does — pytorch/xla #3588 / #8056); the
+accumulated bf16 error goes non-finite. Refs: pytorch/xla #8591, #8778.
+
+Their fix was a custom wrap policy with one outer reduce-scatter.
+
+**This repo's position is that the question may not arise.** Phase 1 trains ~11.5M
+trainable params; Phase 2 adds LoRA r=256 on 18 layers, roughly 75M more. Model ~7.5 GB
+bf16, optimizer state ~1 GB, against 31.25 GiB per chip. `replicated` fits with room.
+
+So `opt-7-strategy` is not a micro-optimization — it is the cheapest way to find out
+whether an entire class of failure applies to this model at all. Run it early.
+
+If FSDPv2 does turn out to be needed: **the wrap policy matches on
+`type(module).__name__`.** A wrong class-name string wraps nothing, silently falls back
+to replicated, and looks like a successful FSDPv2 run. Print the wrap count at startup
+and verify the name against the installed `transformers`.
+
+## 5. Global gates
+
+A candidate must pass **all six** to be promoted. Any single failure is a rollback.
+
+| # | Gate | Threshold |
+|---|---|---|
+| 1 | **Compile** | `xla/compile_cause_delta` reaches 0 after warmup and stays there. A rising counter mid-run is a hard fail regardless of step time. |
+| 2 | **Stability** | Finite loss through the 300-step rung. NaN is never "retry and see" — see §4. |
+| 3 | **Memory** | `mem/hbm_peak_gb` ≤ **29 GiB** on v6e. |
+| 4 | **Quality** | Loss curve within noise of the baseline at the same step count. A speedup that moves the loss curve is not a speedup. |
+| 5 | **Throughput** | p50 step time improves ≥5%, and p90 does not regress. A better mean with a worse tail is a recompile hiding. |
+| 6 | **Rollback** | The change is revertible by one config line or one commit. Anything requiring a coordinated multi-file revert does not get promoted. |
+
+## 6. Phases
+
+Ordered by dependency, not by expected payoff. Phase 0 is mandatory; without it every
+later phase is guesswork.
+
+| Phase | Purpose | Promotion |
+|---|---|---|
+| **0 — Instrument** | Emit the `xla/*`, `xprof/*`, `mem/*`, `host/*` fields. XProf labels: `data_fetch`, `device_transfer`, `forward_loss`, `backward`, `mark_step`, `optimizer_step`, `logging_materialize`. Tracing default-off. | Counters present, overhead <2% |
+| **1 — Logging cadence** | Per-step logging forces syncs | Step time improves, loss still readable |
+| **2 — Compile warmup** | Absorb first-step compile with a zero-LR macro-step | First real step faster |
+| **3 — Batch shape** | Find the images/step the HBM ceiling allows | Gate 3 holds at target effective batch |
+| **4 — Recompute** | Test whether grad checkpointing is needed at `replicated` | Faster, gate 3 holds |
+| **5 — Input pipeline** | Only if `host/input_gap_ms` shows starvation | Gap drops |
+| **6 — Dynamic shapes** | **The VLM-specific phase.** Static-shape image-token scatter; MoonViT bucketing | Gate 1 holds mid-run |
+| **7 — Sharding + kernels** | `replicated` vs FSDPv2; flash attention; `scan_layers` probe | Per-candidate |
+| **8 — Promote** | Full selected config at length | All six gates |
+
+### Phase 6 is where the real work is
+
+Three of this repo's own code paths produce dynamic shapes under XLA:
+
+1. **`models/tiny_aya_vision.py` image-token scatter** — `special_image_mask.nonzero()`
+   plus advanced indexing. This exists because `masked_scatter_backward` is broken under
+   inductor on **CUDA**; on XLA `nonzero` is a dynamic-shape op. The two backends want
+   opposite code, which is precisely what the `src/backend/` seam is for. Do **not** fix
+   this by reverting to `masked_scatter` — that breaks the GPU path.
+2. **`n_image_tokens.item()`** in the same function — a `torch.compiler.is_compiling()`
+   bypass guards it, but that predicate is a **Dynamo** check and is False under
+   torch_xla LazyTensor tracing, so the guard syncs every forward. Confirm with
+   `met.metrics_report()` before acting.
+3. **MoonViT variable tokens** — `num_tokens_after_shuffle: -1` means a new HLO program
+   per distinct image resolution. Unbucketed, MoonViT is not TPU-eligible.
+
+### Phase 7 scan hazards
+
+`scan_layers` has three known failure signatures, all inherited and all in the diagnoser
+as Phase-7-only hazards rather than live rows: `Layer N has mismatched keys`,
+`FakeTensor.*aten.index_select`, and `unexpected keyword attention_mask`. This repo is
+*more* exposed than the source project because Phase 2 makes layers 18-35 structurally
+different from 0-17.
+
+## 7. Experiment record
+
+Every candidate records: `ID` · date · `TRC_PROFILE` · `TPU_STRATEGY` · git SHA ·
+W&B run id · steps · p50/p90 step time · peak HBM · final loss ·
+`compile_cause_count` at end · verdict · one-line rationale.
+
+Full field list and the candidate table: `playbook/optimization-experiment-matrix.md`.
+
+## 8. Stop conditions
+
+Stop the program and escalate when:
+
+1. Two consecutive candidates fail the same gate — the model is telling you the gate is
+   wrong or the bottleneck is elsewhere.
+2. NaN appears at all. Go to §4, not to the next candidate.
+3. `compile_cause_delta` never reaches 0 — a shape is varying and no tuning matters until
+   Phase 6 closes it.
+4. Peak HBM exceeds 29 GiB at the minimum useful batch.
+5. A candidate needs a change to `pipeline/train_*.py` that is not behind the backend
+   seam. That is a `SPEC.md` §9 problem, not an optimization problem.
+6. Wall-clock spent compiling exceeds wall-clock spent training over a full session.
+7. The slice is preempted more than twice during a single candidate — the measurement is
+   contaminated; rerun rather than reporting it.
+8. Any result would need to be written into a `docs/*.md` results table. TPU numbers do
+   not go there until the same entrypoint runs on both backends.

--- a/.claude/orchestration/diagrams/01-architecture.mmd
+++ b/.claude/orchestration/diagrams/01-architecture.mmd
@@ -1,0 +1,49 @@
+---
+title: Tiny Aya Vision TPU orchestration — layers and what each survives
+---
+flowchart TD
+  subgraph L1["Claude session (disposable)"]
+    CS["reads logs, decides, edits code<br/>NEVER owns a long loop"]
+  end
+
+  subgraph L2["Workstation tmux (survives Claude)"]
+    QW["qrwatch-tayavision<br/>scripts/tpu/qr_watch.sh<br/>/tmp/qr_watch_tayavision.log"]
+  end
+
+  subgraph L3["QR metadata (survives node reboot)"]
+    MD["code-tarball-uri<br/>TAYAVISION_ENTRYPOINT<br/>TAYAVISION_HYDRA_OVERRIDES<br/>resume=auto, W&B run identity"]
+  end
+
+  subgraph L4["VM tmux 'train' (survives workstation)"]
+    W0["worker 0<br/>/tmp/train.log"]
+    WN["workers 1..N-1<br/>(N=1 on v6e-8)"]
+  end
+
+  subgraph L5["External (survives everything)"]
+    GCS["gs://tayavision-eu<br/>checkpoints + code tarball"]
+    WB["W&B tayavision-tpu"]
+    NT["ntfy.sh push events"]
+  end
+
+  subgraph L6["Modal / GPU — the authoritative path, unaffected by any of this"]
+    MOD["scripts/modal_*.py<br/>every published result"]
+  end
+
+  CS -.reads.-> QW
+  CS -.reads.-> W0
+  CS -->|modal run| MOD
+  QW -->|recycle on preemption| MD
+  MD -->|boot self-heal| W0
+  W0 -->|deploy_tarball.sh --worker=all| WN
+  W0 <-->|PJRT rendezvous, multi-host only| WN
+  W0 --> GCS
+  W0 --> WB
+  QW --> NT
+  W0 --> NT
+
+  classDef ephemeral fill:#fff3cd,stroke:#856404
+  classDef durable fill:#d4edda,stroke:#155724
+  classDef authoritative fill:#cce5ff,stroke:#004085
+  class CS ephemeral
+  class GCS,WB,NT durable
+  class MOD authoritative

--- a/.claude/orchestration/diagrams/02-state-machine.mmd
+++ b/.claude/orchestration/diagrams/02-state-machine.mmd
@@ -1,0 +1,39 @@
+---
+title: Run loop — DEPLOY / WATCH / CLASSIFY / RECOVER
+---
+stateDiagram-v2
+  [*] --> READY: preflight passes (gcloud auth, .env incl. HF_TOKEN, entrypoint exists)
+
+  READY --> DEPLOY
+
+  DEPLOY: tar working tree incl. .env -> GCS
+  DEPLOY: pull on --worker=all, uv sync + torch_xla[tpu]
+  DEPLOY: relaunch tmux 'train', bake TAYAVISION_RUN_TAG
+  DEPLOY --> WATCH
+
+  WATCH: poll worker 0 log, scoped AFTER this RUN_TAG
+  WATCH: status markers via tail (NEVER head)
+  WATCH: repeating step line fetched separately
+  WATCH: compile-cause counter distinguishes compiling from hung
+
+  WATCH --> WATCH: step lines advancing, compile count flat (T0)
+  WATCH --> WATCH: XLA compile up to 20 min cold (T1)
+  WATCH --> DONE: clean exit
+  WATCH --> CLASSIFY: dirty exit or timeout
+  WATCH --> T3: node preempted / unreachable
+
+  CLASSIFY: match agents/tpu-diagnoser.md, first hit wins
+  CLASSIFY --> DEPLOY: T2 known fix, not a repeat (costs ~14 min recompile)
+  CLASSIFY --> STOP: T4 unknown, or same class twice
+
+  T3: qr_watch sees SUSPENDED/FAILED
+  T3 --> STOP: SAVE_CKPT_DIR is not gs:// -> notify-only
+  T3 --> STOP: budget spent (20) or quota abort
+  T3 --> BOOT: within budget AND checkpoints durable
+
+  BOOT: fetch tarball, resume=auto, same W&B run
+  BOOT --> WATCH
+
+  STOP: STOP + ntfy push
+  STOP --> [*]
+  DONE --> [*]

--- a/.claude/orchestration/diagrams/03-memory-lifecycle.mmd
+++ b/.claude/orchestration/diagrams/03-memory-lifecycle.mmd
@@ -1,0 +1,51 @@
+---
+title: Memory lifecycle — ephemeral runtime data to durable knowledge
+---
+flowchart LR
+  subgraph EPH["Ephemeral (lost on reboot / cleanup)"]
+    TL["/tmp/train.log per worker"]
+    QL["/tmp/qr_watch_tayavision.log"]
+    DL["/tmp/deploy.log"]
+  end
+
+  subgraph AUTO["Automatic capture (hooks)"]
+    PTU["PostToolUse — logs every edit/exec"]
+    STP["Stop — runs VERIFY.md checks"]
+    PRC["PreCompact — snapshots open PLAN items"]
+  end
+
+  subgraph REPO["Durable, in the repo"]
+    PG["PROGRESS.md — append-only log (gitignored)"]
+    PLN["PLAN.md — goal + checklist (gitignored)"]
+    MEM["memories.md — decisions + gotchas (gitignored)"]
+    VER["VERIFY.md — done-criteria (tracked)"]
+    ORCH["orchestration/ — spec, playbook, baselines (tracked)"]
+  end
+
+  subgraph EXT["External, permanent"]
+    WB["W&B tayavision-tpu"]
+    GCS["gs://tayavision-eu checkpoints"]
+  end
+
+  NEXT["next Claude session starts informed"]
+
+  TL --> WB
+  TL --> GCS
+  TL -->|run outcome| PG
+  QL -->|preemption history| PG
+  DL -->|deploy history| PG
+  PTU --> PG
+  STP --> VER
+  PRC --> PG
+  PG -->|pattern seen 2+ times, /remember| MEM
+  PG -->|goal changed, /plan| PLN
+  MEM -->|operational rule| ORCH
+  WB -->|promoted numbers| ORCH
+  MEM -->|SessionStart injection| NEXT
+  PLN --> NEXT
+  ORCH -->|CONTROL_PLANE + TPU_OPTIMIZATION_SPEC injected| NEXT
+
+  classDef eph fill:#f8d7da,stroke:#721c24
+  classDef dur fill:#d4edda,stroke:#155724
+  class TL,QL,DL eph
+  class PG,PLN,MEM,VER,ORCH dur

--- a/.claude/orchestration/diagrams/render.sh
+++ b/.claude/orchestration/diagrams/render.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Render Mermaid .mmd files to SVG (and optionally PNG).
+#
+# Usage:
+#   bash render.sh                # render all *.mmd in this dir
+#   bash render.sh 03-memory-lifecycle.mmd   # render one file
+#
+# Requires mermaid-cli (mmdc):
+#   npm install -g @mermaid-js/mermaid-cli
+# or run via npx: npx @mermaid-js/mermaid-cli -i in.mmd -o out.svg
+#
+# Output goes to ./svg/<name>.svg and ./png/<name>.png
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+mkdir -p svg png
+
+# Pick mmdc path: prefer global, fall back to npx.
+if command -v mmdc >/dev/null 2>&1; then
+    MMDC="mmdc"
+else
+    MMDC="npx -y @mermaid-js/mermaid-cli"
+fi
+
+render_one() {
+    local src="$1"
+    local base
+    base="$(basename "$src" .mmd)"
+    echo "[render] $src -> svg/${base}.svg"
+    $MMDC -i "$src" -o "svg/${base}.svg"
+    echo "[render] $src -> png/${base}.png"
+    $MMDC -i "$src" -o "png/${base}.png"
+}
+
+if [ $# -eq 0 ]; then
+    for f in *.mmd; do
+        [ -e "$f" ] || continue
+        render_one "$f"
+    done
+else
+    for f in "$@"; do
+        render_one "$f"
+    done
+fi
+
+echo "[render] done -> $(pwd)/svg/ and $(pwd)/png/"

--- a/.claude/orchestration/playbook/baseline-v6e8-siglip-cohere2.md
+++ b/.claude/orchestration/playbook/baseline-v6e8-siglip-cohere2.md
@@ -1,0 +1,288 @@
+# Protected baseline — v6e-8, SigLIP + Cohere2 (Tiny Aya Vision)
+
+> **The first real Tiny Aya Vision TPU run happened 2026-07-25** (v6e-16, W&B run
+> `2726cdff`, 20 optimizer steps). Slice, boot, batch, throughput, memory, and loss rows
+> are now **measured**. What remains `TBD` is the long-run behaviour: full-epoch loss,
+> checkpoint/resume, and the regression thresholds.
+>
+> Inherited figures stay confined to the clearly-marked non-authoritative section at the
+> bottom; they belong to a different model. Nothing measured here came from there.
+>
+> Add `baseline-<slice>-<arch>.md` for a new slice rather than editing this one — a
+> protected baseline that gets edited in place stops being a baseline.
+
+## Slice
+
+> **Measured on `v6e-16-ew4a`, not `v6e-8-eu`, on 2026-07-25.** v6e-64 and v6e-32 both
+> failed to provision (see `docs/tpu/tpu-capacity-log.md`); v6e-16 came up clean. Slice
+> rows below are real; **model rows are still TBD** — nothing but a synthetic matmul has
+> run. Rename or split this file when a v6e-8 baseline exists.
+
+| Quantity | Value | Source |
+|---|---|---|
+| `TRC_PROFILE` | `v6e-16-ew4a` | measured |
+| Accelerator | `v6e-16`, **4 workers** | measured — 4 network endpoints, i.e. 4 chips/host, not the 8 public topology tables imply |
+| Chips visible to SPMD | **16** (`global_runtime_device_count`) | measured |
+| Mesh | 1-D over 16 chips, single process | measured |
+| Zone / runtime | `europe-west4-a` / `v2-alpha-tpuv6e` | — |
+| Bucket | `gs://tayavision-eu` (co-located) | created 2026-07-25 |
+| `torch` / `torch_xla` | **2.9.1+cpu / 2.9.0**, `libtpu` 0.0.21 | measured |
+| Python | **3.12 exactly** — floored by pyproject, ceilinged by libtpu cp312 | measured |
+| `TPU_STRATEGY` | `replicated` | default; `opt-7-strategy` untested |
+| HBM per chip | 31.25 GiB usable; **29 GiB working ceiling** | inherited, unverified here |
+
+## Boot and provisioning (measured 2026-07-25)
+
+| Phase | Duration |
+|---|---|
+| QR `WAITING_FOR_RESOURCES` → `PROVISIONING` | ~2 min |
+| `PROVISIONING` → node `READY/HEALTHY` → QR `ACTIVE` | ~3.5 min |
+| **Submit → ACTIVE, total** | **~5.5 min** |
+| apt + uv + tarball fetch + extract | ~25 s |
+| `uv sync` + torch/torch_xla install | ~2 min |
+| T2 redeploy (deps cached) → first step line | **~90 s** |
+
+**The inherited "~14 min cold-boot recompile" did not reproduce**, but this workload is a
+single trivial matmul. Do not treat ~90 s as the model's compile time — that number is
+still TBD and is expected to be far larger.
+
+## Synthetic step timing (NOT a model number)
+
+One `(8,196,2048) @ (2048,2048)` bf16 matmul, i.e. the projector output shape only.
+
+| Metric | Value |
+|---|---|
+| step 1 (compile) | **1.80 s** |
+| p50 warm (steps 4-20) | **0.0005 s** |
+| `xla/compile_cause` markers | **1** — flat after step 1, which is the correct signal |
+| `aten::nonzero` | **absent** (expected — no model code ran) |
+
+Compile is isolated to the first step and the counter stays flat, which is exactly the
+gate-1 behaviour `TPU_OPTIMIZATION_SPEC.md` requires. The 0.0005 s is a ~13 GFLOP op on
+~14 PFLOP/s of silicon; it is overhead-dominated and says nothing about model throughput.
+
+## Model materialized on TPU — MEASURED 2026-07-25
+
+`tpu_smoke.py --load-backbone` on the live v6e-16. Gated `CohereLabs/tiny-aya-base`
+downloaded and materialized; **gate 3 is comfortably satisfied.**
+
+| Quantity | Value |
+|---|---|
+| Params total | **4.33 B** |
+| Params trainable (bare constructor) | **3.90 B (90%)** — see note below |
+| **HBM resident per chip** | **8.058 GiB** |
+| HBM total per chip | **31.246 GiB** (confirms the inherited 31.25) |
+| Headroom under the 29 GiB working ceiling | **~21 GiB** |
+| Chip | `TPU v6e chip`, 4 local chips/host |
+| First step with model resident | 2.62 s (vs 1.79 s without) |
+| Compile-cause markers | 1 — flat after warmup |
+
+8.058 GiB matches `4.33e9 x 2 bytes` exactly, which is the check that the figure is real
+rather than an artifact.
+
+**`replicated` fits with room to spare, and that largely answers `opt-7-strategy`.** At
+8.06 GiB of a 29 GiB working ceiling, the whole model sits on every chip with ~21 GiB
+left for activations, gradients, and optimizer state. The inherited FSDPv2 per-layer
+reduce-scatter NaN (`../SPEC.md` §7) is therefore **avoidable rather than survivable** on
+this model — do not reach for FSDPv2 until a real memory pressure appears.
+
+### Measured with a real training step (2026-07-25)
+
+| Config | Per-chip HBM | Outcome |
+|---|---|---|
+| B_global 256, seq 640, **no input sharding** | — | **OOM.** HLO showed ~20 live `bf16[64,640,11008]` temps at 860 MB each |
+| B_global 256, seq 640, **input sharding on** | **17.14 / 31.2 GiB** | fits, under the 29 ceiling |
+
+### Do not trust the analytical activation model
+
+It has now been wrong **three times in one session**, always low:
+
+1. Used `hidden_size` 2048 for the dominant term. Cohere2's FFN `intermediate_size` is
+   **11008** — 5.38x larger, and it is the MLP intermediates that actually dominate.
+2. Assumed the per-chip batch was `B_global / chips`. Nothing sharded the input, so every
+   chip held the whole per-**host** batch of 64. `MpDeviceLoader` does not shard by
+   itself; it needs `input_sharding=ShardingSpec(mesh, ("data", None))`.
+3. Even corrected, it predicted 10.2 GiB against a measured 17.1 — XLA keeps far more
+   fused temporaries alive concurrently than "boundaries plus a working set" suggests.
+
+**Gate 3 of `../TPU_OPTIMIZATION_SPEC.md` is enforced by outcome, not by arithmetic.**
+Size batches by bisection and read `mem/used_gib`; treat the formula as an order-of-
+magnitude sanity check only, and never as a reason to skip the measurement.
+
+> **Trainable-parameter caveat.** 3.90 B trainable is the *bare constructor*: only
+> `SigLIPVisionEncoder.__init__` freezes anything. Phase 1's ~11.5 M-trainable figure
+> comes from the training pipeline freezing the LLM, not from the model class. Do not
+> read 90% as a bug, and do not read it as the Phase-1 configuration either.
+
+### How the HBM figure is obtained, and one correction
+
+`xm.get_memory_info()` is unusable under SPMD: it defaults to `xla_device()`, which is
+the *virtual* device `SPMD:0`, and `_xla_memory_info` rejects it. `torch_xla.devices()`
+returns that same virtual device. The raw strings from
+`_XLAC._xla_get_all_runtime_devices()` fail differently — `get_memory_info` calls
+`str(device)` and `torch.device` cannot parse the format.
+
+`tpu_info.metrics.get_chip_usage()` reads libtpu's gRPC metrics server and **works**.
+
+An earlier entry here claimed its `MEMORY_USAGE` gauge "does not track program
+allocations", based on pinning 8 GiB of `torch.zeros` and seeing ~0. **That conclusion
+was wrong and is retracted.** The gauge is fine; the test was not — a buffer that no
+computation consumes is dead-code-eliminated by XLA before it is ever allocated. Loaded
+weights cannot be elided, which is why they register. The lesson generalises: on a lazy,
+optimising backend, *allocating* something is not the same as it existing.
+
+## Model
+
+| Quantity | Value |
+|---|---|
+| Vision encoder | `google/siglip2-so400m-patch14-384`, frozen, ~400M |
+| Image tokens | **196** (384/14 → 27×27=729 → pad 28 → pixel-shuffle 2 → 196) |
+| Connector | `MultiModalProjector`, ~11.5M trainable |
+| LLM | `CohereLabs/tiny-aya-base` — Cohere2, 3.35B, **36 layers**, d=2048 |
+| Total / trainable (Phase 1) | ~3.75B / ~11.5M |
+| Precision | bf16 |
+
+## Batch configuration — MEASURED 2026-07-25 (v6e-16, run `2726cdff`)
+
+| Quantity | Value |
+|---|---|
+| Images per **chip** per micro-step | **8** |
+| Per-host DataLoader batch | **32** (= 128 / 4 hosts) |
+| Global images per micro-step | **128** |
+| Grad accumulation | **2** |
+| **Effective batch** | **256 — identical to the Modal GPU baseline** |
+| Sequence length | **640**, fixed (`training.fixed_seq_len=640`) |
+| Micro-steps per epoch | **4,360** (139,532 per host / 32, `drop_last`) |
+| Optimizer steps per epoch | **2,180** |
+
+`B_eff` matching the Modal baseline is deliberate: it is invariant #2 of
+`perf-metrics-schema.md`, and it is what makes this run's loss curve comparable to the GPU
+one. LR stays 1e-3 and `warmup_ratio` 0.03 for the same reason.
+
+**Global batch 256 does NOT fit** — see the memory section. 128x2 was chosen to preserve
+`B_eff` while halving activation memory.
+
+## Throughput — MEASURED 2026-07-25
+
+| Metric | Value |
+|---|---|
+| `perf/step_time` p50 (per **optimizer** step, i.e. 2 micro-steps) | **1.494 s** |
+| Spread, steps 4-19 | **1.491-1.503 s** — essentially zero variance |
+| `perf/images_per_sec` | **171.4** |
+| Step 1 (compile) | **160.8 s** |
+| Step 2 (residual compile) | **54.8 s** |
+| First warm step | step 4 |
+| `xla/compile_cause_count` at steady state | **1, FLAT for all 19 steps** |
+| Projected 1-epoch wall clock | **~54 min** (2,180 x 1.494 s) |
+
+The flat compile counter is the gate-1 signal from `TPU_OPTIMIZATION_SPEC.md` and it
+confirms the fixed-`S` collate: with dynamic padding every batch is a new shape and this
+number climbs forever.
+
+**The inherited "~14 min cold-boot recompile" still did not reproduce** — 160.8 s for a
+real model step, not 840 s.
+
+## Memory — MEASURED 2026-07-25
+
+| Metric | Value |
+|---|---|
+| `mem/used_gib` peak, B_global=128 | **27.80** of 31.25 |
+| `mem/used_gib` typical | 25.2-25.3 |
+| `mem/total_gib` | **31.246** |
+| B_global=256 | **OOM at step 2** — "reserve 16.25G ... 15.69G free" |
+
+At B_global=256 the run completed step 1 (loss 9.0502) and died loading step 2's program.
+The margin at 128 is real but not generous: **27.80 of a 29 GiB working ceiling.**
+
+### The analytical activation model has now been wrong FOUR times, always low
+
+The fourth: predicted ~19.4 GiB for B_global=128 by halving the measured 256 figure;
+actual peak **27.8**. Halving the batch did **not** halve total memory, because the static
+term and XLA's live fused temporaries do not scale with batch.
+
+**Gate 3 is enforced by outcome, not arithmetic** — bisect the batch and read
+`mem/used_gib`. Treat any formula here as an order-of-magnitude check only.
+
+## Loss reference — MEASURED 2026-07-25 (20 optimizer steps, B_eff 256, LR 1e-3)
+
+| Opt step | `train/loss` | `train/grad_norm` | `train/lr` |
+|---:|---|---|---|
+| 1 | 9.053 | — | 1.54e-05 |
+| 5 | 8.519 | — | 7.7e-05 |
+| 10 | 7.365 | — | 1.54e-04 |
+| 15 | 6.727 | — | 2.31e-04 |
+| 19 | **5.714** | 19.50 | 2.92e-04 |
+
+Monotone apart from small wiggles at steps 9, 11-12. Still inside warmup at step 19
+(`warmup_ratio` 0.03 of 2,180 = 65 steps), so the LR has not yet reached 1e-3.
+
+`train/max_image_tokens` = **196** every step, which is the SigLIP token invariant holding.
+`norms/projector_token_mean` 8.64, `norms/emb_matrix_mean` 1.23.
+
+## Checkpoint + resume
+
+| Check | Status |
+|---|---|
+| `SAVE_CKPT_DIR` reaches the training code | **yes** — `pipeline/utils.gcs_checkpoint_root()` |
+| Exactly one rank writes | **yes, measured** — rank 0 logged `Saved checkpoint`, the other three silent |
+| Objects written per save | **1** — `<root>/<run_id>/checkpoint_<micro_step>.pt`, 69 MB |
+| Checkpoint mirrored to `gs://` | **verified end-to-end 2026-07-26** |
+| Resume with an EMPTY local `/models` | **verified end-to-end 2026-07-26** |
+| Optimizer + LR-scheduler state restored | **yes** — `train_alignment.py:694-696` |
+| Resumed run rejoins the same W&B run id | **yes** — `wandb: Resuming run a2d64c8e...` |
+| Resume from `TAYAVISION_RESUME=auto` | **verified end-to-end 2026-07-26** — resolves the run id, fetches, resumes, rejoins the same W&B run, with no Hydra `resume=` override |
+| Default deploy does NOT silently resume | **verified** — `deploy_tarball.sh` defaults to `off`, so a redeploy against a prefix full of checkpoints still starts a fresh run id |
+
+### How durability was verified (not asserted)
+
+1. Ran with `save_steps=2`, saw `Saved checkpoint ...` immediately followed by
+   `Mirrored checkpoint to gs://.../<run_id>/checkpoint_N.pt`.
+2. Confirmed the objects independently with `gcloud storage ls -l` — 2 objects, 132 MiB.
+3. **Deleted `/models/<run_id>` on all four hosts** to simulate a recycle.
+4. Relaunched with `resume=<run_id>`; the log showed
+   `Fetched gs://.../checkpoint_17.pt -> /models/...` then `Resuming from step 17`,
+   and training continued and mirrored again.
+
+Two real bugs surfaced only because step 3 was actually performed:
+
+- **`torch.load(map_location=<xla device>)` raises.** "don't know how to restore data
+  location of torch.storage.UntypedStorage (tagged with xla:0)" — and the tag names the
+  *target*, not the file. TPU now loads to host and lets `load_state_dict` place it.
+- **The resumed step counter double-counted.** `step = step_offset + _i` is right only on
+  the GPU *subset* path. On the TPU *skip* path the loader still yields the whole epoch,
+  so `_i` is already absolute. Resuming from step 8 reported step 16, tripped `max_steps`
+  instantly, and exited "Training complete" having done no work at all.
+
+Neither is visible without a real resume, which is why "it writes to `gs://`" is not the
+same claim as "it survives a preemption."
+
+## Regression triggers
+
+Fill the thresholds once the baseline exists. The shape:
+
+- p50 step time > ~2× baseline, sustained, after ruling out a recompile.
+- `xla/compile_cause_delta` non-zero mid-run — a shape is varying; see diagnoser rows on
+  `nonzero`, MoonViT, and generation.
+- Peak HBM > 29 GiB.
+- MFU below TBD%.
+- Any change in images per step or the 196-token invariant — that makes the number
+  incomparable rather than merely worse.
+
+---
+
+## Non-authoritative inherited envelope
+
+**Different model. Do not cite these as Tiny Aya Vision numbers.** From
+`tinyaya-stage2-scale` v6e-16 hardening probes (2026-07-14), recorded in
+`docs/tpu/tpu-capacity-log.md`. They are here because they bound what is plausible on
+first boot, not because they predict this model.
+
+| Quantity | Observed (speech model, v6e-16) | Transfers? |
+|---|---|---|
+| Step time | 1.79-1.85 s | **No** — different model, different batch |
+| HBM peak | 25.7-27.8 GiB of 31.25 | **Partly** — the 31.25 GiB ceiling is silicon, the usage is not |
+| Cold-boot recompile | ~14 min | **Yes** — a property of torch_xla on v6e SPMD |
+| XLA persistent cache hit rate | ~0, nondeterministic keys | **Yes** — toolchain behaviour |
+
+The two "yes" rows are why `tier-definitions.md` budgets 20 minutes for T1 and why the
+watchdog's `compiling` threshold is 20 min rather than the JAX sibling's 10.

--- a/.claude/orchestration/playbook/diagnosis-table.md
+++ b/.claude/orchestration/playbook/diagnosis-table.md
@@ -1,0 +1,35 @@
+# Diagnosis table — pointer
+
+**The diagnosis table is canonical in `.claude/agents/tpu-diagnoser.md`.** This file is a
+pointer, deliberately. It is not a summary, and it must never become a second copy.
+
+`tinyaya-stage2-scale` carried the table in five places — the playbook, the agent, the
+SPEC, the orchestrate skill, and the watchdog — and they drifted. By the time anyone
+noticed, the playbook copy said "13 entries" while the file had 15, and the skill's row 1
+described a signature that existed nowhere else. A diagnosis table that disagrees with
+itself is worse than no table: it makes a confident wrong classification.
+
+## Routing
+
+| You want | Go to |
+|---|---|
+| Detection — signature → classification | `.claude/agents/tpu-diagnoser.md` |
+| Policy — classification → what to do | `tier-definitions.md` |
+| Recovery mechanics — how a tier is executed | `../SPEC.md` §4-5 |
+| Whether it should work at all yet | `../SPEC.md` §9 |
+
+## Adding a signature
+
+1. Add the row to `.claude/agents/tpu-diagnoser.md` — signature, classification, action,
+   tier. Nowhere else.
+2. If it needs a tier that does not exist, update `tier-definitions.md` **first**. A row
+   pointing at an undefined tier is unactionable.
+3. If the fix is structural rather than operational, record it in `.claude/memories.md`
+   too — the table says what to do now, memories says why the shape is what it is.
+4. Prefer a signature that matches the **cause** over one that matches a downstream
+   symptom. The worked example: a multi-host `DEADLINE_EXCEEDED` rendezvous failure was
+   really an apt/dpkg lock race on two workers. Matching the rendezvous error alone cost
+   an hour of looking at the wrong layer.
+5. Mark provenance. Rows inherited from a sibling project are predictions here until
+   observed; rows derived from this repo's code but never seen are predictions too. Say
+   which.

--- a/.claude/orchestration/playbook/event-taxonomy.md
+++ b/.claude/orchestration/playbook/event-taxonomy.md
@@ -1,0 +1,47 @@
+# Event taxonomy
+
+Push events, not blocking prompts. `tinyaya-stage2-scale` required a blocking `AskUser`
+snapshot at T+15/30/45/60/90 min; that assumes a human watching a single foreground run,
+and it would stall an overnight run at the first milestone.
+
+Events are emitted by `notify()` in `scripts/tpu/_lib.sh`, which is a **no-op when
+`NTFY_TOPIC` is unset**. Call sites are therefore unconditional — nothing has to check
+whether notifications are configured, and a first run with no `.env` works, just deaf.
+
+## Events
+
+| Source | Event | When | Why it matters |
+|---|---|---|---|
+| `qr_watch` | `QR state changed` | QR leaves `ACTIVE` | First warning that capacity was lost |
+| `qr_watch` | `resubmitted (n/20)` | after a recycle | Confirms self-heal fired; the counter is the flap signal |
+| `qr_watch` | `quota abort` | quota-class failure | Resubmitting cannot help — needs a human. Usually `IN_USE_ADDRESSES`, not chips. |
+| `qr_watch` | `recycle BLOCKED — SAVE_CKPT_DIR not gs://` | preemption with local checkpoints | Self-heal was declined **on purpose**; recycling would restart from step 0 and re-pay ~14 min of compile |
+| `qr_watch` | `budget exhausted` | 20 resubmits spent | Run is stopped, capacity is gone |
+| `qr_watch` | heartbeat | every 2h | Proves the watcher itself is alive |
+| `deploy_tarball` | `deployed tag=<RUN_TAG> to N worker(s)` | fan-out complete | The tag is what scopes every later log query |
+| `train_launcher` | `entrypoint missing: <path>` | launch, pre-exec | Catches a typo'd `TAYAVISION_ENTRYPOINT` in seconds instead of 20 min into a spot acquisition |
+| `train_launcher` | `run OK — <last metric line>` | clean exit | The result, without opening W&B |
+| `train_launcher` | `run FAILED rc=<n> — <tail>` | dirty exit | Slice is idle and needs a look |
+
+## Design rules
+
+1. **Every event carries its outcome, not just its occurrence.** `run OK — step=1000
+   loss=2.41` beats `run finished`. An event you have to go look something up after is
+   only half an event.
+2. **A silent watcher is indistinguishable from a dead one**, hence the 2-hour heartbeat.
+   The absence of bad news is not good news.
+3. **Never push per-step or per-interval progress.** Metrics belong on W&B. A muted topic
+   is worse than no topic, and the fastest way to get a topic muted is to make it noisy.
+4. **Terminal events say what is now idle.** The expensive mistake is not a failed run;
+   it is a slice sitting unused for six hours because nobody knew the run ended.
+
+## Where to look when an event arrives
+
+| Event | First thing to open |
+|---|---|
+| Any `qr_watch` failure | `/tmp/qr_watch_tayavision.log`, then `ops.sh status` |
+| `recycle BLOCKED` | Your `SAVE_CKPT_DIR` — point it at `gs://tayavision-eu/...` and redeploy |
+| `run FAILED` | worker 0 `/tmp/train.log` **tail-first**, then `tpu-diagnoser` |
+| `entrypoint missing` | `TAYAVISION_ENTRYPOINT` in your launch env; `../SPEC.md` §9 for what is legal |
+| `run OK` | `https://wandb.ai/cataluna84/tayavision-tpu`, then `ops.sh delete` if you are done |
+| heartbeat gap > 2h | `tmux ls` on the workstation — has `qrwatch-tayavision` died? |

--- a/.claude/orchestration/playbook/optimization-experiment-matrix.md
+++ b/.claude/orchestration/playbook/optimization-experiment-matrix.md
@@ -1,0 +1,64 @@
+# Optimization experiment matrix
+
+Ported from `tinyaya-stage2-scale` and re-derived for a vision-language model. Governed
+by `../TPU_OPTIMIZATION_SPEC.md`, which owns the gates; this file owns the candidate list.
+
+**Status: nothing has been run.** Every row is a hypothesis. The `Result` column stays
+empty until a real run fills it — an invented result here would propagate into
+`baseline-*.md` and then into `docs/`.
+
+## Standard run ladder
+
+Kept verbatim from the source, because the shape is what makes results comparable:
+
+| Rung | Steps | Purpose | Gate to advance |
+|---|---:|---|---|
+| **Smoke** | 20 | Does it compile and produce a step? | No crash; `xla/compile_cause_delta` → 0 |
+| **Failure boundary** | 300 | Does it survive the window where NaN and OOM live? | Finite loss; HBM ≤ 29 GiB |
+| **Promotion** | 1000 | Is it actually faster, and still correct? | p50 step time improves ≥5%; loss curve within noise of baseline |
+| **Production** | full | The real run | — |
+
+A candidate that fails at rung N is never promoted past it. The 300-step rung exists
+because the inherited FSDPv2 NaN appeared at step 24-130 — a 20-step smoke would have
+called it green.
+
+## Candidates
+
+| ID | Phase | Hypothesis | Change | Ladder | Promote if | Roll back if |
+|---|---|---|---|---|---|---|
+| `opt-0-metrics` | 0 | We cannot tune what we cannot see | Emit the `xla/*` + `xprof/*` fields in `perf-metrics-schema.md`; XProf labels on, tracing default-off | 20 | Counters appear and are plausible | Overhead >2% step time |
+| `opt-1-log25` | 1 | Per-step logging forces a device sync | `log_every: 25` | 300 | Step time improves, loss curve unchanged | Loss becomes unreadable |
+| `opt-2-warmup` | 2 | A zero-LR warmup step absorbs compile before real data | One compile-warmup macro-step | 300 | `first_visible_step_compile_s` unchanged, first real step faster | No measurable change |
+| `opt-3-imgbatch` | 3 | Images/step is the memory axis on a VLM, not sequence length | Sweep images/step at fixed effective batch via grad-accum | 20→300 | HBM headroom without step-time loss | OOM or NaN |
+| `opt-4-nockpt` | 4 | Gradient checkpointing may be unnecessary at `replicated` | `xla_grad_checkpoint: false` | 20→300 | Faster and HBM ≤ 29 GiB | OOM |
+| `opt-5-mpdl` | 5 | Host input pipeline starves the device | `MpDeviceLoader` + prefetch; `num_workers` sweep | 300 | `host/input_gap_ms` drops | No change — then the bottleneck is elsewhere |
+| `opt-6-nonzero` | 6 | **The highest-value row.** `nonzero()` in the image-token scatter is a dynamic-shape op that recompiles per distinct image count | Replace `nonzero` + `index_put` in `models/tiny_aya_vision.py` with a static-shape `torch.where`, **behind the backend seam** so CUDA keeps its own path | 20→300 | `compile_cause_delta` → 0 mid-run; `aten_fallback_count` drops | GPU path changes numerically — it must not |
+| `opt-6-moonvit-buckets` | 6 | MoonViT's variable token count can be bucketed | Fixed token buckets, every bucket graph prewarmed | 300 | Compile count bounded by bucket count | Unbounded compiles — then MoonViT stays GPU-only |
+| `opt-7-strategy` | 7 | `replicated` may beat FSDPv2 outright here | A/B `replicated` vs `fsdpv2_lora` on the Cohere2 backbone | 300 | `replicated` fits and is faster | HBM > 29 GiB at target batch |
+| `opt-7-flash` | 7 | Flash attention on the SigLIP encoder | Attention backend A/B | 300 | Faster, loss unchanged | Any loss delta |
+| `opt-7-scan` | 7 | `scan_layers` reduces compile time | Isolated probe only | synth→300 | Compile time drops materially | Any of the three scan signatures fires — see the diagnoser |
+| `opt-8-promote` | 8 | The selected config holds at length | Full selected config | 1000→full | All gates in `../TPU_OPTIMIZATION_SPEC.md` §5 pass | Any gate fails |
+
+### Why `opt-7-scan` is last and isolated
+
+`scan_layers` requires homogeneous, pure layers. Phase 2 puts LoRA on layers **18-35
+only**, so layers 0-17 have a different parameter structure by construction — this repo
+is *more* likely to hit `Layer N has mismatched keys` than the source project was. It is
+a probe, never a default. `use_scan_layers: false` is in the protected config.
+
+### Why `opt-7-strategy` might close several rows at once
+
+Phase 1 trains ~11.5M params of ~3.75B; the model is ~7.5 GB bf16 against 31.25 GiB/chip.
+If `replicated` fits comfortably — and the arithmetic says it should — then the inherited
+FSDPv2 per-layer reduce-scatter NaN is **sidestepped rather than worked around**, and the
+wrap-policy hazard in `../SPEC.md` §7 stops being a live risk for Phase 1 entirely. That
+would be the single most valuable result in this table, and it is cheap to get.
+
+## Required record fields
+
+Every promoted or rejected candidate records: `ID` · date · `TRC_PROFILE` ·
+`TPU_STRATEGY` · git SHA · W&B run id · steps run · p50/p90 step time · peak HBM ·
+final loss · `compile_cause_count` at end · verdict (`promote` / `reject` / `rollback` /
+`needs-more-data`) · one-line rationale.
+
+A candidate without a W&B run id and a git SHA is not a result, it is a recollection.

--- a/.claude/orchestration/playbook/perf-metrics-schema.md
+++ b/.claude/orchestration/playbook/perf-metrics-schema.md
@@ -1,0 +1,89 @@
+# Performance metrics schema
+
+Fields emitted to W&B `cataluna84/tayavision-tpu`. Deliberately a separate project from
+`tayavision-instruct-sweep` and `tayavision-multilingual` so TPU bring-up noise never
+lands in a results project.
+
+Merged from `llm-architectures` (identity / training / throughput shape) and
+`tinyaya-stage2-scale` (the XLA and XProf namespaces, which JAX had no use for and this
+stack needs most).
+
+## Identity
+
+| Field | Source | Notes |
+|---|---|---|
+| `WANDB_RUN_NAME` | launch env | Human-readable, e.g. `v6e8-smoke-01` |
+| `WANDB_RUN_ID` | launch env | **Fixed** for resumable runs — a preemption must rejoin, not fork |
+| `TAYAVISION_RUN_TAG` | `deploy_tarball.sh` | Unique per deploy; baked into the launch log line so log segments can be scoped |
+| `TRC_PROFILE` | launch env | Which slice produced the number. A step time without a slice is meaningless. |
+| `TPU_STRATEGY` | launch env | `replicated` \| `fsdpv2_lora` \| `fsdpv2` |
+
+Empty `WANDB_*` exports break `wandb.init` with `Run ID cannot be empty`. Launchers must
+export only when set **and** the init path must scrub empties — either half alone has
+been observed to fail.
+
+## Training
+
+| Field | Unit | Meaning |
+|---|---|---|
+| `train/loss` | nats | Per-step training loss |
+| `train/lr` | — | Current LR |
+| `train/grad_norm` | — | Pre-clip gradient norm |
+| `val/loss` | nats | Validation loss |
+
+## Throughput
+
+| Field | Unit | Formula |
+|---|---|---|
+| `perf/step_time` | s | Measured wall time per optimizer step |
+| `perf/p50_step_time`, `p90`, `p99` | s | Percentiles. **A mean hides tail stalls**, and on XLA the tail is where recompiles live. |
+| `perf/images_per_sec` | img/s | images per step / step_time |
+| `perf/tokens_per_sec` | tok/s | Text tokens; report alongside images, never instead |
+| `perf/mfu` | fraction | achieved FLOP/s ÷ (peak × chips) |
+
+## XLA and profiling
+
+The namespace that matters most on this stack, and the one the JAX sibling has no
+analogue for. Source: `torch_xla.debug.metrics.metrics_report()`.
+
+| Field | Meaning |
+|---|---|
+| `xla/compile_cause_count` | Cumulative compilations. **Flat = steady state. Rising = a shape is varying.** This single counter is what distinguishes a normal 14-minute cold boot from a genuine hang, and it is what four of the VLM diagnosis rows key on. |
+| `xla/compile_cause_delta` | Compilations since the last log. Should be 0 after warmup. Non-zero mid-run means dynamic shapes — see diagnoser rows on `nonzero`, MoonViT, and generation. |
+| `xla/first_visible_step_compile_s` | Seconds from launch to the first step line. Expect ~840s (~14 min) cold. |
+| `xla/aten_fallback_count` | Ops that fell back to CPU. `aten::nonzero` and `aten::_local_scalar_dense` here are the dynamic-shape smoking gun. |
+| `xprof/profile_path` | GCS path of the captured trace |
+| `xprof/trace_window` | Step range the trace covers |
+
+Phase 0 of `../TPU_OPTIMIZATION_SPEC.md` instruments these seven XProf labels:
+`data_fetch`, `device_transfer`, `forward_loss`, `backward`, `mark_step`,
+`optimizer_step`, `logging_materialize`.
+
+## Memory and host
+
+| Field | Meaning |
+|---|---|
+| `mem/hbm_peak_gb` | Peak HBM per chip. Ceiling is **29 GiB** of 31.25 usable on v6e. |
+| `mem/model_gb` | Materialized model size — expect ~7.5 GB bf16 |
+| `host/input_gap_ms` | Time the device waited on the input pipeline |
+| `host/device_transfer_ms` | Host→device copy time |
+
+## Invariants that make numbers comparable
+
+1. **196 image tokens per image** on the SigLIP path. A run at a different token count is
+   not comparable and must not share a chart.
+2. **Report the effective batch, not the per-device batch.** Per-device batch × chips ×
+   grad-accum is the only quantity that compares across slices.
+3. **Images per step is the memory-relevant axis**, not sequence length. A VLM's
+   activation peak scales with images × 196, so an OOM is fixed by cutting images first.
+4. **`TRC_PROFILE` and `TPU_STRATEGY` are part of every number.** Step time from a v6e-8
+   and a v5e-64 are different measurements, not two samples of one.
+5. **Phase 2' only**: the 40% English / 60% multilingual mix and T=5 temperature sampling
+   must match the GPU run, or loss curves are not comparable across backends.
+
+## Leaderboard fields
+
+`run.summary` should carry final/best `val/loss`, total images seen, wall-clock, MFU,
+peak HBM, and `TRC_PROFILE`. Verify all six before promoting anything into
+`playbook/baseline-*.md` — and note that a TPU number never enters a `docs/*.md` results
+table until the same entrypoint has run on both backends (`../SPEC.md` §7).

--- a/.claude/orchestration/playbook/tier-definitions.md
+++ b/.claude/orchestration/playbook/tier-definitions.md
@@ -1,0 +1,64 @@
+# Tier definitions
+
+The escalation ladder. Lower tiers are less disruptive and preferred when the failure
+mode is well understood.
+
+**This table splits the two source policies at T3.** `tinyaya-stage2-scale` locked T3 to
+"always escalate — never auto-recreate the QR". `llm-architectures` inverted it and
+auto-recycles. Here T3 is automatic **only when checkpoints are durable** — see the
+`gs://` gate below and `../SPEC.md` §5.
+
+| Tier | Action | Trigger | Auto? | Disruption |
+|------|--------|---------|-------|------------|
+| **T0** | Continue | All signals nominal; step lines advancing, compile-cause count flat | yes | none |
+| **T1** | Wait it out | Known-benign stall: XLA compile (**budget 20 min cold, not 10**), checkpoint write, first-batch dataset materialization | yes | none |
+| **T2** | Redeploy with patch | Classified, fixable error from the diagnosis table (config/env/code) | yes | ~2 min tarball + relaunch, **plus a full recompile** |
+| **T3** | Recycle the queued resource | Node preempted, `SUSPENDED`/`FAILED`, or hosts unreachable | **conditional** — `qr_watch.sh` recycles iff `SAVE_CKPT_DIR` is a `gs://` URI; otherwise notify-only | ~10-30 min: new spot acquisition, then boot self-heal |
+| **T4** | Stop and notify | Budget spent, quota-class abort, repeat classification, non-durable checkpoints, or unknown signature | n/a | indefinite — needs a human |
+
+**T2 costs more here than on the JAX sibling.** A redeploy on torch_xla throws away the
+XLA executable cache, and that cache has nondeterministic keys on v6e SPMD so it never
+warm-hits. Budget ~14 min of recompile per T2, not the ~1 min a JAX redeploy costs. Batch
+your fixes: two T2s in a row for two separate one-line patches is half an hour of silicon
+spent on compilation.
+
+## Auto-escalation to T4
+
+Stop and push a notification regardless of tier when:
+
+1. The same classification fires twice consecutively (circuit breaker — the patch is not
+   working, and here each retry burns ~14 min of compile with it).
+2. `MAX_RESUBMITS` (20) is exhausted.
+3. The QR failure is quota-class. On this grant the commonest such wall is
+   `IN_USE_ADDRESSES` (regional cap 8, and every 8-host slice wants exactly 8), not TPU
+   chips.
+4. **`SAVE_CKPT_DIR` is not a `gs://` URI.** Recycling without durable checkpoints
+   restarts from step 0 and re-pays the compile, silently, up to twenty times.
+5. The failure signature is not in the diagnosis table.
+6. A second resubmitter is detected for the same QR.
+7. **Loss goes non-finite.** NaN on this backbone has a known structural cause
+   (`../SPEC.md` §7, FSDPv2 per-layer reduce-scatter); it is never a "retry and see"
+   condition.
+
+## Locked invariants
+
+- **One resubmitter per QR, ever.** `qr_watch.sh` exits if the QR is absent rather than
+  racing a human mid-recreate. Two resubmitters produce duplicate nodes and split-brain
+  rendezvous.
+- **T3 auto-recycle is bounded**, never unbounded. Budget plus cooldown is what separates
+  self-healing from a flapping loop that burns a day of capacity.
+- **T3 auto-recycle requires durable checkpoints.** This is the tayavision-specific brake.
+  Self-healing that discards all progress is not self-healing.
+- **T2 redeploys are only safe mid-run when checkpointing and resume are configured.** A
+  redeploy kills `train` on every worker; without `SAVE_CKPT_DIR` +
+  `TAYAVISION_RESUME=auto` that discards progress.
+- **T1 is a real tier, not a stalling tactic.** On torch_xla most apparent hangs are a
+  compile. Capture the compile-cause counter from `met.metrics_report()` as evidence
+  before escalating anything that looks like a stall — elapsed time alone cannot tell a
+  14-minute normal boot from a deadlock.
+
+## Classification source
+
+The signature → classification table is canonical in `.claude/agents/tpu-diagnoser.md`.
+This file owns *policy* (what to do at each tier); that file owns *detection* (which tier
+a log belongs to).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session_start.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/user_prompt_submit.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post_tool_use.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stop.py",
+            "timeout": 90
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre_compact.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session_end.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/archive-progress/SKILL.md
+++ b/.claude/skills/archive-progress/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: archive-progress
+description: Move PROGRESS.md entries older than 90 days (or beyond 500 total lines) into .claude/archive/PROGRESS-YYYY-Qn.md. Use when PROGRESS.md grows unwieldy or as part of monthly maintenance.
+---
+
+# Archive Progress
+
+Keeps `.claude/PROGRESS.md` lean by moving old entries to a quarterly archive.
+Used by `/curate` and the `memory-curator` subagent.
+
+## When to run
+
+- Monthly, as routine maintenance.
+- Whenever `wc -l .claude/PROGRESS.md` exceeds 500. (The upstream log reached
+  2,784 lines before anyone ran this — check occasionally.)
+- Before a major branch cut where you want a clean log.
+
+## Steps
+
+1. Read `.claude/PROGRESS.md`.
+2. Parse the file into entry blocks: each starts with
+   `## YYYY-MM-DDTHH:MM:SSZ ...`. The H1, the `<!-- progress:marker -->` line,
+   and any hand-written narrative section are not entries.
+3. Compute the cutoff: `now - 90 days`, configurable via `MEMORY_ARCHIVE_DAYS`.
+4. Group entries older than the cutoff by `YYYY-Qn` from their timestamp.
+5. Append each group, in chronological order, to
+   `.claude/archive/PROGRESS-YYYY-Qn.md`. Create the file if absent with a
+   1-line header `# PROGRESS archive YYYY Qn`.
+6. Remove the archived entries from PROGRESS.md. **Leave the H1 and the
+   `<!-- progress:marker -->` line intact** — the marker is the ordering
+   contract for every subsequent write.
+7. Add a single `info | session` entry noting the count and destination files.
+
+## Idempotency
+
+- Archive files are append-only; rerunning is a no-op for entries already moved.
+- Never deletes from archive files.
+
+## Success criteria
+
+- `wc -l .claude/PROGRESS.md` decreases.
+- `<!-- progress:marker -->` still present (the `memory-system` VERIFY block
+  checks this).
+- Total entry count across PROGRESS + all archives is unchanged.
+
+## Failure modes
+
+- Permission denied on the archive dir -> create it and retry; report and stop
+  on a second failure.
+- Malformed entry header -> skip it and log a warning to PROGRESS.md.
+
+## Composes with
+
+- `update-progress` — used to record the archival event.
+- `memory-curator` (subagent) — runs this skill plus a dedupe pass.

--- a/.claude/skills/keep-context-fresh/SKILL.md
+++ b/.claude/skills/keep-context-fresh/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: keep-context-fresh
+description: Master entry-point for the external memory system. Invoke at the start of any non-trivial task to load PROGRESS, PLAN, VERIFY, and memories.md, then propose the next action consistent with what's recorded. Use when the user asks "where were we", "what's the state", "load context", or starts a new goal.
+---
+
+# Keep Context Fresh
+
+The master skill for the external memory system. It guarantees that every
+non-trivial session begins from the same snapshot of state.
+
+## When to use
+
+- The user starts a new task and you have no recent memory of the goal.
+- The user asks "where were we?", "load context", "recall the state".
+- A new session begins after a `clear`, compact, or restart.
+- Before producing a plan that touches multiple files or subsystems.
+
+## Steps
+
+1. Read all four canonical memory files:
+   - `.claude/PROGRESS.md` (last 30 entries — newest are at the top, directly
+     under `<!-- progress:marker -->`)
+   - `.claude/PLAN.md` (in full)
+   - `.claude/VERIFY.md` (in full)
+   - `.claude/memories.md` (in full)
+
+2. Root `CLAUDE.md` and `AGENTS.md` are already in the system prompt — Claude
+   Code loads them natively. Do **not** re-read them; that just burns context.
+
+3. If the task touches TPU work, a training run, or anything under `scripts/tpu/`,
+   also read:
+   - `.claude/orchestration/CONTROL_PLANE.md` — which surface owns which fact, and
+     which of the two compute paths is authoritative for it
+   - `.claude/orchestration/SPEC.md` — the run loop. **§9 says what does not work
+     yet**; read it before proposing to launch anything.
+
+   Skip this step for pure Modal/GPU work. The SessionStart hook already injected
+   the first 100 lines of CONTROL_PLANE.md, so re-read it only for a row the
+   truncation cut.
+
+4. Render a concise state summary in chat as plain markdown — headings, tables,
+   and lists. Do not emit `<json-render>` blocks or any other widget markup;
+   Claude Code renders those as literal text. Include:
+   - Goal (from PLAN's `## Goal`)
+   - Top 5 unchecked PLAN items
+   - Top 5 most recent PROGRESS entries with status
+   - The `# verify: <id>` ids currently defined in VERIFY.md
+   - If step 3 ran: the active `TRC_PROFILE` and whether a QR is live
+   - One line: "What I'd do next", derived from PLAN and PROGRESS
+
+5. Ask the user to confirm the goal before proceeding to actual edits.
+
+## Inputs
+
+- Optional `goal: <string>` override if the user names a different goal.
+
+## Success criteria
+
+- All four memory files were read in the current session (verifiable in the
+  tool log).
+- The user has either confirmed the goal or asked for plan regeneration — in
+  which case invoke the `plan-driver` subagent.
+
+## Failure modes
+
+- If any memory file is missing, do **not** silently continue. Surface the gap
+  and offer to recreate it following `.claude/MEMORY-SYSTEM.md`.
+
+## Composes with
+
+- `recall-context` — programmatic recall, no chat output.
+- `plan-driver` (subagent) — for goal -> PLAN.md generation.
+- `verify` — for running the VERIFY.md blocks.

--- a/.claude/skills/recall-context/SKILL.md
+++ b/.claude/skills/recall-context/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: recall-context
+description: Background knowledge skill. Auto-loads when the agent plans a multi-step task; reads memory files into context without rendering them in chat. Use when starting a substantive change.
+---
+
+# Recall Context
+
+A silent, model-only counterpart to `keep-context-fresh`. Loaded automatically
+when a task is judged non-trivial; it does not appear in the slash-command
+palette.
+
+## When the agent invokes this
+
+- Before generating a multi-file plan or refactor.
+- Before answering a question that requires knowing prior decisions (e.g. "why
+  does the model force DynamicCache instead of HybridCache?").
+- Before producing a commit message that should align with the PROGRESS log.
+
+## Steps
+
+1. Read `.claude/PROGRESS.md`, last 50 lines.
+2. Read `.claude/memories.md` in full.
+3. Read `.claude/PLAN.md` in full.
+4. Root `CLAUDE.md` and `AGENTS.md` are already in the system prompt — do not
+   re-read them.
+5. If the task touches TPU work, also read `.claude/orchestration/CONTROL_PLANE.md`
+   §0 and §2 (the two compute paths and the source-of-truth table), plus
+   `.claude/agents/tpu-diagnoser.md` when a log excerpt is in play. Skip for
+   Modal/GPU work.
+6. Produce no chat output. Internal reasoning only. Make subsequent decisions
+   consistent with what was just read.
+
+## Success criteria
+
+- The next action references at least one memory entry by date or decision
+  title (e.g. "per the 2026-07-25 decision on the PROGRESS marker").
+
+## When NOT to invoke
+
+- Trivial single-line edits.
+- Questions answered entirely by code in the working tree.
+- When the user explicitly asks for a fresh take ("ignore prior decisions").

--- a/.claude/skills/tpu-orchestrate/SKILL.md
+++ b/.claude/skills/tpu-orchestrate/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: tpu-orchestrate
+description: Run-control playbook for Tiny Aya Vision TPU runs — how orchestration is layered, where truth lives, and the recovery ladder. Load when operating, debugging, or resuming a TPU run.
+---
+
+# TPU run-control (Tiny Aya Vision)
+
+> **No entrypoint under `pipeline/` runs on TPU today.** `train_alignment.py`,
+> `train_instruct.py`, and `train_multilingual.py` are DDP + CUDA. Read
+> `.claude/orchestration/SPEC.md` §9 before launching anything. The default entrypoint is
+> `scripts/tpu/tpu_smoke.py`, which proves provisioning — not training.
+>
+> The Modal/GPU path is unaffected and remains authoritative for every published result.
+
+## Where to look
+
+| Need | File |
+|---|---|
+| Surface ownership; which compute path owns a fact | `orchestration/CONTROL_PLANE.md` |
+| Run loop + recovery policy + what does not work yet | `orchestration/SPEC.md` |
+| What to do at each tier | `orchestration/playbook/tier-definitions.md` |
+| Signature → classification | `.claude/agents/tpu-diagnoser.md` |
+| Is the run healthy right now | `.claude/agents/tpu-watchdog.md` |
+| Protected config + promotion gates | `orchestration/TPU_OPTIMIZATION_SPEC.md` |
+| Known-good numbers | `orchestration/playbook/baseline-v6e8-siglip-cohere2.md` |
+| Metric names + comparability rules | `orchestration/playbook/perf-metrics-schema.md` |
+| ntfy event meanings | `orchestration/playbook/event-taxonomy.md` |
+| The actual commands | `docs/tpu/tpu-runbook.md` |
+
+## Layering
+
+1. **VM tmux `train`**, every worker — launched by `startup_script.sh` at boot and by
+   `deploy_tarball.sh` on redeploy, via `train_launcher.sh`. Log `/tmp/train.log`.
+   Deploys kill and relaunch on all workers (`--worker=all`).
+2. **Workstation tmux `qrwatch-tayavision`** — `qr_watch.sh`: forensics → quota check →
+   durability gate → delete → identical resubmit. Log `/tmp/qr_watch_tayavision.log`.
+   The suffix matters; a bare `qrwatch` on this workstation is `llm-architectures`'.
+3. **Boot self-heal via QR metadata** — tarball URI, entrypoint, Hydra overrides,
+   `resume=auto`, W&B identity. A preemption *reboot* (QR survives) recovers with zero
+   action.
+4. **Claude session** — never owns a loop that must outlive it.
+
+## Recovery ladder (least → most invasive)
+
+1. **Read.** `ops.sh tail-logs`, or the `tpu-watchdog` agent. Most apparent hangs are a
+   compile; budget 20 minutes cold and check the compile-cause counter, not the clock.
+2. **Redeploy (T2).** `deploy_tarball.sh`. Costs a full ~14 min recompile here — batch
+   your fixes rather than making two one-line trips.
+3. **Recycle the QR (T3).** `qr_watch.sh` does this automatically **only when
+   `SAVE_CKPT_DIR` is a `gs://` URI**. Manually: delete the QR, then `launch_spot.sh`
+   with the same env. One resubmitter per QR, ever.
+4. **Zone rotation.** Follow the fallback tree in `docs/tpu/tpu-capacity-log.md` §1 —
+   it leads with EU because there is one bucket, `gs://tayavision-eu`, and a US zone pays
+   egress on every write.
+
+## Invariants
+
+- **196 image tokens per image** on the SigLIP path. MoonViT's variable count means a new
+  HLO program per shape and is not TPU-eligible unbucketed.
+- **`DistributedSampler` off under SPMD.** One process holding a 1/N shard trains on 1/N
+  of the data and reports nothing wrong.
+- **Never wrap `Cohere2DecoderLayer` in an FSDPv2 auto-wrap policy** — 36 wraps, 36 bf16
+  reduce-scatters, known NaN. `replicated` is the default and probably sufficient.
+- **Tarball deploys including `.env`, never a git clone.** It is the only way `HF_TOKEN`
+  reaches the VM, and `CohereLabs/tiny-aya-*` is gated.
+- **One resubmitter per QR.**
+- **Long loops live in tmux**, never in a Claude session.
+- **No TPU number enters a `docs/*.md` results table** until the same entrypoint runs on
+  both backends.
+
+## Optimization mode
+
+Only once a run is stable. `TPU_OPTIMIZATION_SPEC.md` owns the six gates and the
+nine-phase program; `playbook/optimization-experiment-matrix.md` owns the candidates and
+the 20 → 300 → 1000 → full run ladder.
+
+Start with `opt-0-metrics` (you cannot tune what you cannot see) and `opt-7-strategy`
+(cheapest way to find out whether the inherited FSDPv2 NaN applies to this model at all).

--- a/.claude/skills/tpu-redeploy/SKILL.md
+++ b/.claude/skills/tpu-redeploy/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: tpu-redeploy
+description: Push the local working tree to a live TPU slice and relaunch, without recreating the queued resource. Covers multi-host fan-out and mid-run safety rules.
+---
+
+# Redeploy to a live TPU slice
+
+This is the **T2** action in the recovery ladder. It never touches the queued resource —
+a lost node is T3 and belongs to `qr_watch.sh`.
+
+> **A redeploy here costs a full XLA recompile (~14 min)**, unlike the ~1 minute it costs
+> on the pure-JAX sibling: the persistent cache has nondeterministic keys on v6e SPMD and
+> never warm-hits. Batch your fixes. Two T2s for two one-line patches is half an hour of
+> silicon spent compiling.
+
+## What it does
+
+1. Tars the working tree **including the gitignored `.env`** — the only way `HF_TOKEN`
+   (for the gated `CohereLabs/tiny-aya-*` repos), `WANDB_API_KEY`, and `NTFY_TOPIC` reach
+   the VM. There is no git clone anywhere in this flow.
+2. Uploads to `gs://tayavision-eu/code/` (stamped + `latest.tar.gz`).
+3. Pulls and extracts over `$REPO_DIR` on every worker, preserving `.venv` and any staged
+   datasets.
+4. `uv sync` (CPU torch) + `uv pip install torch_xla[tpu]`, and re-resolves `LD_LIBRARY_PATH` for
+   `torch_xla`'s `_XLAC.so`.
+5. Kills and relaunches tmux `train` via `train_launcher.sh`, with a unique
+   `TAYAVISION_RUN_TAG` baked into the launch line so later log queries can be scoped.
+
+## Invocation
+
+```bash
+TAYAVISION_ENTRYPOINT=scripts/tpu/tpu_smoke.py \
+TAYAVISION_HYDRA_OVERRIDES="vision=siglip llm=base wandb.project=tayavision-tpu" \
+TPU_STRATEGY=replicated \
+SAVE_CKPT_DIR=gs://tayavision-eu/checkpoints/smoke-01 \
+ZONE=europe-west4-a NODE_ID=tayavision-v6e8 \
+bash scripts/tpu/deploy_tarball.sh
+```
+
+Precedence: shell env > repo-root `.env` > script defaults. Defaults target `v6e-8-eu`.
+
+## Mid-run safety
+
+Three things must hold before redeploying a run you want to keep:
+
+- **`SAVE_CKPT_DIR` set, and a `gs://` URI.** A redeploy kills `train` on every worker.
+  Without durable checkpoints that discards progress — and `qr_watch.sh` will also refuse
+  to auto-recycle on the next preemption (`SPEC.md` §5).
+- **`TAYAVISION_RESUME=auto`**, or the relaunch starts from step 0.
+- **`WANDB_RUN_ID` fixed**, or the resumed run forks a second W&B entry instead of
+  rejoining.
+
+## Multi-host rules
+
+Only relevant on `v6e-64` (8 hosts) or `v5e-64` (16 hosts). `v6e-8-eu`, the default, is
+single-host and skips all of this.
+
+- Fan out with `--worker=all`. Every host must relaunch or the PJRT rendezvous hangs the
+  survivors until `DEADLINE_EXCEEDED`.
+- Gate on every worker reporting startup complete in `/tmp/startup.log` before launching.
+- Re-run a missing worker's startup **detached** (`nohup … &` or tmux) — never a
+  foreground ssh with a local `timeout`.
+- Every multi-host profile is currently blocked on the `IN_USE_ADDRESSES` regional cap
+  (8, and an 8-host slice wants exactly 8). See `docs/tpu/tpu-capacity-log.md` §7.1.
+
+## Gotchas
+
+- **`ImportError: libpython3.12.so.1.0`.** `torch_xla`'s `_XLAC.so` dynamically links
+  libpython, which uv keeps outside the default loader path. The redeploy must re-export
+  `LD_LIBRARY_PATH` from the uv Python root, exactly as `startup_script.sh` does — this
+  is the torch_xla-specific step the JAX sibling has no equivalent of.
+- **A killed `gcloud ssh` does not kill the remote command.** A local `timeout` around it
+  orphans the remote process. Long remote work goes in a detached session with an
+  explicit liveness check.
+- **Never pipe a critical deploy step through `head`.** SIGPIPE kills it mid-work.
+- **`which uv` is empty under sudo.** Use `/root/.local/bin/uv` in root contexts.
+- **Empty `WANDB_*` exports break `wandb.init`** with `Run ID cannot be empty`. Export
+  only when non-empty.
+
+## After deploying
+
+Watch the tag-scoped segment of worker 0's `/tmp/train.log`. Read status markers from the
+**tail**; fetch the repeating per-step line separately. Expect no step line for up to 20
+minutes on a cold boot — that is compilation, not a hang. Confirm with the compile-cause
+counter rather than the clock.

--- a/.claude/skills/update-plan/SKILL.md
+++ b/.claude/skills/update-plan/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: update-plan
+description: Maintain .claude/PLAN.md - tick completed items, add new sub-tasks, edit Definition of Done. Idempotent. Use when work has progressed and the plan needs to reflect reality.
+---
+
+# Update Plan
+
+Edits PLAN.md in place. The Stop hook ticks items automatically via their
+`<!-- verify:<id> -->` tags; humans can call `/plan` (which delegates to the
+`plan-driver` subagent for full regeneration) or add `#plan <task>`
+quick-capture lines.
+
+`PLAN.md` owns only the active goal, phase checklist, and Definition of Done.
+Chronological events go in `PROGRESS.md`, durable decisions in `memories.md`.
+
+## Inputs
+
+One of:
+
+- `tick: <substring>` — find the first matching `- [ ]` line and promote it to
+  `- [x]`.
+- `add: <text>` — add a new `- [ ] <text>` under `## Tasks`.
+- `dod_add: <text>` — add a new bullet under `## Definition of Done`.
+- `regenerate: true` — delegate to the `plan-driver` subagent.
+
+## Steps
+
+1. Read `.claude/PLAN.md`.
+2. Apply the requested edit:
+   - `tick`: case-insensitive substring search; replace `- [ ]` with `- [x]` on
+     the first match. If no match, fail loudly.
+   - `add`: append under `## Tasks`, before any `## Out of scope`.
+   - `dod_add`: append under `## Definition of Done`.
+3. Write the file back atomically.
+4. If all Definition of Done items are checked, append a milestone entry to
+   `memories.md` and a `done | plan` entry to `PROGRESS.md`.
+
+## Auto-ticking from VERIFY
+
+A PLAN item tagged `<!-- verify:<id> -->` is ticked by the Stop hook whenever
+the VERIFY.md block with that `# verify: <id>` first line passes. Prefer that
+tag over a manual `tick:` for anything a check already covers — it cannot drift.
+
+## Idempotency
+
+- Ticking an already-checked item is a no-op.
+- Adding an item that already exists (substring match on the body) is a no-op.
+
+## Success criteria
+
+- The applied diff is minimal — a single-line change for `tick`, a single-line
+  insert for `add`.
+- The file still parses as markdown, and the literal `## Tasks` heading
+  survives (the `#plan` router depends on it).
+
+## Failure modes
+
+- `## Tasks` heading missing -> refuse to add; ask the user to seed PLAN.md per
+  `.claude/MEMORY-SYSTEM.md`.
+- More than one match for `tick` -> tick the first and warn.

--- a/.claude/skills/update-progress/SKILL.md
+++ b/.claude/skills/update-progress/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: update-progress
+description: Append a structured entry to .claude/PROGRESS.md with timestamp, branch, sha, status, kind, and detail. Use when the user asks to log a change, capture a failure, or record a decision after the fact.
+---
+
+# Update Progress
+
+Programmatic interface to the running log. Used by hooks and subagents; humans
+should prefer `/progress` or the `#progress` quick-capture trigger.
+
+`PROGRESS.md` owns chronological events: edits, commands, verification results,
+session boundaries. Durable decisions graduate to `memories.md`; procedures
+belong in `.claude/MEMORY-SYSTEM.md` or the repo's `docs/`.
+
+## Inputs
+
+- `status`: one of `info | done | fail | block` (required)
+- `kind`: one of `edit | exec | decide | plan | verify | session` (required)
+- `summary`: a one-line summary, <= 280 chars (required)
+- `detail`: optional multi-line block
+
+## Steps
+
+1. Read `.claude/PROGRESS.md` and locate the `<!-- progress:marker -->` line.
+2. Compose the entry:
+   ```
+   ## <iso8601 utc> | <branch>@<short-sha> | <status> | <kind>
+   <summary>
+
+   <detail>
+   ```
+3. Insert it **immediately below the marker**, so the newest entry is first.
+   If the marker is absent, re-seed it under the H1 — do not append at the end
+   of the file. (Upstream searched for a `---` separator the file never
+   contained, so 572 entries silently appended at EOF in reverse of the
+   documented order.)
+4. Run the same secret-scrub regexes as `_lib.py` before writing.
+5. Confirm to the caller in one short line.
+
+## Success criteria
+
+- The new entry is the topmost dated entry in PROGRESS.md.
+- Branch and short-sha match `git rev-parse --abbrev-ref HEAD` and
+  `git rev-parse --short HEAD`.
+- No secret patterns survived the scrub.
+
+## Failure modes
+
+- File missing -> recreate it per the "Rebuilding from scratch" section of
+  `.claude/MEMORY-SYSTEM.md` (H1, blank line, marker) and retry.
+- Read-only -> surface the error; do not silently swallow it.
+
+## Composes with
+
+- `update-plan` — typically runs together when a plan item completes.
+- `archive-progress` — runs after this skill to keep the file lean.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: verify
+description: Read .claude/VERIFY.md, execute every fenced bash block in order, and report pass/fail in a structured table. Use when the user asks "is it done", "/verify", or before declaring any milestone complete.
+---
+
+# Verify
+
+Runs the curated verification blocks and produces a clean pass/fail report. The
+Stop hook invokes this automatically after every response; humans invoke it via
+`/verify`.
+
+## Steps
+
+1. Parse `.claude/VERIFY.md`. Extract every fenced ` ```bash ` block, preserving
+   order. **Blocks fenced ` ```sh ` are documentation and `#verify` proposals —
+   never execute them.** The slow and known-red checks live there and in
+   `/verify-full`.
+2. Each block is identified by its `# verify: <id>` first line. Use that id in
+   all reporting; it is also what ties the block to a `<!-- verify:<id> -->`
+   tag in PLAN.md.
+3. For each block:
+   - Run with `bash -eo pipefail -c <block>` from the repo root.
+   - Capture stdout + stderr (last 400 chars).
+   - Record exit code and elapsed time.
+   - Honor a 15-second per-block timeout, and a cap of 5 blocks.
+4. Render a markdown table with columns `#`, `id`, `status`, `time (s)`,
+   `exit`, `tail`. Do not emit `<json-render>` or other widget markup — Claude
+   Code renders it as literal text.
+5. If all pass:
+   - Tick matching `<!-- verify:<id> -->` items in `.claude/PLAN.md` via the
+     `update-plan` skill.
+   - Append a `done | verify` entry to PROGRESS.md.
+6. If any fail:
+   - Append a `fail | verify` entry with the failing block id and its tail.
+   - List the failed ids at the bottom of the output.
+
+## Skips
+
+A block that guards optional tooling and prints `skip: <reason>` before
+exiting 0 counts as **skipped**, not passed. Report it as such — a run where
+everything skipped is not a green run.
+
+## Budget
+
+15s per block x a cap of 5 blocks = 75s, inside the 90s `Stop` timeout in
+`settings.json`. Never add a check slower than about 2 seconds: this runs after
+every single assistant response. pytest (171s here, and red without an HF token
+for the gated `CohereLabs/tiny-aya-*` repos) belongs in `/verify-full` or CI.
+
+## Success criteria
+
+- The table exhaustively reflects every ` ```bash ` block in VERIFY.md.
+- A run of any outcome leaves the working tree unchanged — confirm with
+  `git status --short`.
+
+## Failure modes
+
+- VERIFY.md missing -> point the user at `.claude/MEMORY-SYSTEM.md`.
+- A block exceeds 15s -> kill it and report `timeout`.
+- A block prints to stderr but returns 0 -> still a pass; the stderr lands in
+  the `tail` column.
+
+## Composes with
+
+- `update-plan` — called on full pass to tick PLAN items.
+- `update-progress` — called regardless, to log the verification.

--- a/.env.example
+++ b/.env.example
@@ -12,14 +12,27 @@
 # worker with `OSError: gated repo` (diagnoser row 2).
 HF_TOKEN=
 
+# Local tooling only; not read by the TPU path.
+JUPYTER_PORT=8888
+TENSORBOARD_PORT=6006
+KAGGLE_USERNAME=
+KAGGLE_KEY=
+
 # Optional. Absent -> the run trains but is unobservable
 # (`no WANDB_API_KEY found` in the log).
 WANDB_API_KEY=
+# scripts/tpu/train_launcher.sh injects these as Hydra overrides when they are
+# non-empty, and pipeline/train_multilingual.py reads WANDB_PROJECT directly
+# (it has no `cfg` in scope at its wandb.init). Keep bring-up runs off any
+# project that holds published results.
+WANDB_PROJECT=tayavision-tpu
+WANDB_ENTITY=
 
 # Optional. Absent -> notify() becomes a no-op: self-healing still works,
 # silently. Tolerable for a foreground smoke, not for an overnight run.
 # Pick any unguessable string; it is a public pub/sub topic.
 NTFY_TOPIC=
 
-# Optional. Defaults to ml-pipelines-315702 (the TRC grant project).
-PROJECT_ID=ml-pipelines-315702
+# Optional. Blank is fine -- scripts/tpu/_lib.sh falls back to the TRC grant
+# project (ml-pipelines-315702). Set it only to point the scripts elsewhere.
+PROJECT_ID=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Copy to .env and fill. `.env` is gitignored (.gitignore:151) and is SHIPPED TO
+# THE TPU VM inside the code tarball — that is deliberate, and it is the only way
+# credentials reach the worker, because there is no git clone in the TPU flow.
+#
+# Append with `printf '\n%s\n'`, never `echo X >>`. A file with no trailing
+# newline silently concatenates the new key onto the previous line, and the
+# variable then does not exist. That cost a sibling project a full day of
+# dropped alerts.
+
+# REQUIRED. CohereLabs/tiny-aya-base and -global are GATED repos. Without an
+# authorised token the run cannot start — it fails before step 1 on every
+# worker with `OSError: gated repo` (diagnoser row 2).
+HF_TOKEN=
+
+# Optional. Absent -> the run trains but is unobservable
+# (`no WANDB_API_KEY found` in the log).
+WANDB_API_KEY=
+
+# Optional. Absent -> notify() becomes a no-op: self-healing still works,
+# silently. Tolerable for a foreground smoke, not for an overnight run.
+# Pick any unguessable string; it is a public pub/sub topic.
+NTFY_TOPIC=
+
+# Optional. Defaults to ml-pipelines-315702 (the TRC grant project).
+PROJECT_ID=ml-pipelines-315702

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,56 @@
+name: tests
+
+# Complements ci-cd.yml (the `/run scripts/modal_*.py` PR-comment dispatcher),
+# which does not run tests or lint.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        # CPU wheels: the default index in pyproject.toml is CUDA 12.4, which
+        # is a multi-GB download the runner has no GPU to use.
+        env:
+          UV_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
+        run: uv sync --group dev
+
+      - name: Lint
+        run: uv run --no-sync ruff check .
+
+      - name: Backend seam
+        # torch_xla must stay confined to src/backend/tpu_backend.py. A leak
+        # elsewhere drags libtpu into the import graph and breaks this whole job
+        # at import time. Runs before the tests because it explains them failing.
+        run: bash scripts/ci/check_backend_seam.sh
+
+      - name: Test
+        # 17 tests in test_processing.py and test_vlm_assembly.py load the gated
+        # CohereLabs/tiny-aya-{base,global} repos. With an HF_TOKEN secret that
+        # has access they run; without one they are skipped rather than failing
+        # the build, so forks still get a green signal on the other 112.
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          if [ -n "$HF_TOKEN" ]; then
+            uv run --no-sync pytest tests/ -q
+          else
+            echo "::notice::No HF_TOKEN secret; skipping the 17 gated-repo tests."
+            uv run --no-sync pytest tests/ -q \
+              --ignore=tests/test_processing.py \
+              --ignore=tests/test_vlm_assembly.py
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ __pycache__/
 *.json
 *.jsonl
 
+# Claude Code hook wiring. The blanket *.json rule above would hide it, leaving
+# anyone who clones with a .claude/ that has no hooks registered. Per-contributor
+# state (PROGRESS.md, PLAN.md, memories.md) is excluded by .claude/.gitignore.
+!.claude/settings.json
+
 # C extensions
 *.so
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,186 @@
+# CLAUDE.md
+
+Tiny Aya Vision — a multilingual vision-language model built for the Tiny Aya
+Expedition (Cohere Labs community project). A frozen SigLIP 2 vision encoder is
+bolted onto the Tiny Aya LLM through a small trainable connector.
+
+> `AGENTS.md` at the root is a **Modal SDK cheat-sheet**, not project
+> instructions. It is there because the production compute path runs on Modal.
+> This file is the project guide.
+
+## Compute paths
+
+| Path | Status | Where | Notes |
+|---|---|---|---|
+| **Modal / GPU** (DDP + CUDA) | **Authoritative** | `scripts/modal_*.py`, apps `tayavision-train-alignment` / `-eval` / `-pytest`, volumes `tayavision-{data,models}` / `multilingual-data` | Every published number, checkpoint, and eval came from here. Unchanged. |
+| **TPU / torch_xla** (SPMD) | **Experimental** | `scripts/tpu/*.sh`, TRC grant in `docs/tpu/`, design in `.claude/orchestration/` | Provisioning and supervision only. **No training entrypoint runs on TPU yet.** |
+
+The Modal path is not being replaced. The TPU work adds a second way to run the
+*same* `pipeline/train_*.py`, behind a `src/backend/` seam **that does not exist
+yet** — `pipeline/train_*.py` is DDP + CUDA today. Until that lands, nothing
+under `scripts/tpu/` can train this model, and no TPU number belongs in a
+results table. See `.claude/orchestration/SPEC.md` §9.
+
+Do **not** edit `pipeline/train_*.py` to "just add TPU support" inline; that
+breaks the Modal path for everyone. The seam exists to prevent it.
+
+## Architecture
+
+```
+SigLIP2-so400m-p14-384 (frozen, ~400M)
+  -> (B, 729, 1152) patch embeddings          # 384/14 = 27, 27x27 = 729
+  -> MultiModalProjector                       # ~11.5M trainable
+       pad 27x27 -> 28x28, PixelShuffle 2x2, LayerNorm,
+       Linear(4608 -> 2048), SwiGLU chunk-gate, Linear(1024 -> 2048)
+  -> (B, 196, 2048)                            # (28//2)^2 = 196 tokens/image
+  -> scattered into <image> placeholder positions
+  -> CohereLabs/tiny-aya-{base,global}         # Cohere2, 3.35B, 36 layers, d=2048
+```
+
+~7.5 GB in bf16 — fits a 24 GB GPU. The token arithmetic above is enforced by
+the `config-contracts` check in `.claude/VERIFY.md`; changing any of
+`image_size`, `patch_size`, `downsample_factor`, or the derived counts in
+`config/vision/siglip.yaml` will fail it.
+
+MoonViT (`moonshotai/MoonViT-SO-400M`) is wired as an alternative encoder with a
+`linear_mlp` connector and native-resolution tiling, so it emits a *variable*
+token count per image. It has produced no results yet — see `.claude/PLAN.md` P1.
+
+## Layout
+
+| Path | What |
+|---|---|
+| `src/vision_encoders/` | `base.py` (ABC), `siglip.py`, `moonvit.py`, `create_vision_encoder` factory keyed on `config.vision_encoder_type` |
+| `src/vision_encoder.py` | 10-line back-compat shim; `VisionEncoder = SigLIPVisionEncoder` |
+| `src/connector.py` | `MultiModalProjector` (pixel shuffle, SigLIP), `LinearMLPProjector` (MoonViT), `create_projector` factory |
+| `src/processing.py` | `TinyAyaVisionProcessor` — patches the chat template, expands each `<image>` marker into placeholder tokens (196 fixed for SigLIP, `H*W` from `image_grid_hws` for MoonViT) |
+| `models/tiny_aya_vision.py` | `TinyAyaVisionForConditionalGeneration` (HF `PreTrainedModel` + `GenerationMixin`) |
+| `models/__init__.py` | Registers with `AutoConfig`/`AutoModel`/`AutoModelForCausalLM`/`AutoProcessor` **at import time** |
+| `pipeline/` | `train_alignment.py` (Phase 1), `train_instruct.py` (Phase 2), `train_multilingual.py` (Phase 2'), `data.py`, `multilingual_data.py`, `apply_lora.py`, `utils.py` |
+| `evaluation/` | `run_eval.py` (wraps lm-eval), `tiny_aya_vision_lm_eval.py` (custom backend), `tasks/` (123 YAMLs across cvqa, xmmmu, mtvqa, maxm, kaleidoscope, global_mgsm) |
+| `config/` | Hydra YAML (`config.yaml`, `vision/`, `training/`, `evaluation/`) **plus** Python dataclasses (`model_config.py`, `training_config.py`, `multilingual_config.py`, `lora_config.py`) |
+| `scripts/` | ~18 Modal apps, data downloaders, `merge_weights.py` |
+
+## Training phases
+
+1. **Alignment** — LLaVA-Pretrain (558K caption pairs). Only the projector
+   trains. LR 1e-3, bsz 8 x grad-acc 32.
+2. **Instruct** — LLaVA-v1.5-mix665k. Projector + LoRA (r=256, alpha=512) on the
+   **upper half** of the LLM (layers 18-35). LR 2e-5, global bsz 128.
+3. **Multilingual instruct** — a 9-source mix targeting ~15K samples/language
+   across all 67 Tiny Aya languages. mT5-style temperature sampling (T=5),
+   40% English / 60% multilingual (the Pangea finding).
+4. **Weight merging** (post-hoc) — LERP the fine-tuned LLM backbone toward the
+   original text-only Tiny Aya at alpha in {0.3..0.7} to recover text ability.
+   Only `language_model.*` keys interpolate; projector and encoder are copied
+   verbatim from the fine-tuned checkpoint.
+
+## Commands
+
+```bash
+uv sync --group dev                  # setup; uv is authoritative, not requirements.txt
+
+# Training (Hydra; config/config.yaml is the root)
+# ALWAYS pass training=alignment for Phase 1. config.yaml defaults to
+# `training: instruct`, so a bare `python pipeline/train_alignment.py` silently
+# runs with instruct's lr=2e-5 (50x too low), batch 128/grad-acc 8, a lora block,
+# data_dir=/data/llava-instruct (the WRONG dataset), and logs to
+# wandb project tayavision-instruct-sweep.
+python pipeline/train_alignment.py training=alignment
+python pipeline/train_alignment.py training=alignment vision=siglip llm=global training.batch_size=16
+python pipeline/train_alignment.py resume="<uuid>"
+python pipeline/train_instruct.py training=instruct
+python pipeline/train_multilingual.py training=multilingual_instruct
+modal run scripts/modal_train_alignment.py vision=siglip              # remote
+
+# Evaluation
+uv run evaluation/run_eval.py --task cvqa --model-name <repo> \
+  --backend tiny-aya-vision --apply-chat-template --chunk-size 100
+./eval_cvqa.sh            # CVQA on the multilingual model
+./eval_cvqa_merged.sh     # alpha sweep over merged checkpoints
+./merge_weights.sh        # LERP merge + push to hub
+
+# Checks
+uv run ruff check .                  # must be 0 — also a Stop-hook gate
+uv run pytest tests/ -q              # 129 tests
+uv run pytest tests/ -q -m "not requires_gpu"
+```
+
+Tests run remotely via `modal run scripts/modal_pytest.py` (A10G). On a PR,
+commenting `/run scripts/modal_<name>.py` dispatches that Modal app — see
+`docs/modal_computes_on_pr_comment.md`.
+
+## Gotchas
+
+- **`models` is a side-effect import.** `import models` registers the HF Auto
+  classes. Eval scripts rely on a bare `import models`; do not "clean up" those
+  imports (they carry `# noqa: F401`).
+- **Generation forces `DynamicCache`.** `_prepare_cache_for_generation` overrides
+  Cohere2's default `HybridCache`, which triggers a static-cache compile path
+  that hangs during prefill (`models/tiny_aya_vision.py:235`).
+- **Image merging uses `index_put`, not `masked_scatter`.**
+  `masked_scatter_backward` produces incorrect shapes under `torch.compile` /
+  inductor (`models/tiny_aya_vision.py:170`).
+- **`prepare_inputs_for_generation` merges image features early**, before the LM
+  trims `input_ids` — afterwards `forward()` can no longer locate `<image>`
+  positions.
+- **`pipeline/train_{instruct,multilingual}.py` set `TORCHINDUCTOR_CACHE_DIR`
+  and extend `sys.path` before importing torch.** That ordering is load-bearing;
+  both files carry a `per-file-ignores = ["E402"]` entry in `pyproject.toml`.
+- **`requirements.txt` is stale.** It lists `hydra-core`, `orjson`, and
+  `unsloth` (removed from `pyproject.toml` in c5826fd to unbreak `uv sync`) and
+  omits `hydra-zen`, `matplotlib`, `modal`. Treat `pyproject.toml` + `uv.lock`
+  as authoritative.
+- **17 tests need gated HF repos.** `tests/test_processing.py` and
+  `tests/test_vlm_assembly.py` load `CohereLabs/tiny-aya-{base,global}`. Without
+  an `HF_TOKEN` that has access, they error with `OSError: gated repo`. The
+  other 112 pass offline.
+- **`config/config.yaml` defaults to `training: instruct`.** So
+  `python pipeline/train_alignment.py` with no override runs Phase 1 using
+  *Phase 2* settings: `lr=2e-5` instead of `1e-3`, `batch=128/grad_acc=8`
+  instead of `8/32`, a `lora` block that means nothing for alignment,
+  `data_dir=/data/llava-instruct` instead of `/data/llava-pretrain`, and
+  `wandb.project=tayavision-instruct-sweep`. **Always pass `training=alignment`.**
+  Verified 2026-07-25 by composing the config directly.
+- **`.gitignore` has a blanket `*.json`.** Committed JSON needs `git add -f` or
+  a negation — that is why `!.claude/settings.json` exists.
+- **`docs/architecture.md` predates the `src/vision_encoders/` refactor** and
+  still describes `src/vision_encoder.py` as the encoder.
+- **The `index_put` workaround is backend-specific in *both* directions.**
+  `models/tiny_aya_vision.py:173` uses `nonzero` + advanced indexing because
+  `masked_scatter_backward` is broken under inductor on CUDA — and `nonzero` is
+  a *dynamic-shape* op that XLA cannot trace without falling back to CPU or
+  recompiling per image count. The two backends want opposite code. The fix
+  belongs behind the `src/backend/` seam, not in either branch unconditionally.
+- **MoonViT emits a variable token count per image** (`src/processing.py`),
+  which is fine on CUDA and is unbounded recompilation on XLA. PLAN P1 (produce
+  a MoonViT number) belongs on the Modal path.
+- **`train_multilingual.py:146` hardcodes `project="tayavision-multilingual"`**
+  and ignores the Hydra `wandb.project` override, so a TPU run would contaminate
+  the GPU project. One-line fix; belongs with the backend-seam work.
+
+## Conventions
+
+- Python >= 3.12, `uv` for everything. `ruff check .` must stay at 0.
+- Hydra overrides on the command line, never edited into the YAML for a one-off.
+- No emojis in code, comments, or commit messages.
+- Upstream is the shared `Cohere-Labs-Community` repo. Do not commit or push
+  without being asked.
+
+## Memory system
+
+`.claude/` holds an external memory system: session context is auto-injected
+from `PLAN.md` / `PROGRESS.md` / `memories.md` / `orchestration/`, work is
+auto-logged, and `.claude/VERIFY.md` runs after every response. Read
+`.claude/MEMORY-SYSTEM.md` before changing anything under `.claude/hooks/`.
+
+`.claude/orchestration/` is the TPU run-control design: `CONTROL_PLANE.md`
+(which surface owns which fact, across both compute paths), `SPEC.md` (the run
+loop, and §9 on what does not work yet), `TPU_OPTIMIZATION_SPEC.md`, and a
+`playbook/`. The canonical diagnosis table is `.claude/agents/tpu-diagnoser.md`
+— `playbook/diagnosis-table.md` is a pointer to it and must never become a
+second copy.
+
+Quick capture: start a prompt with `#progress`, `#plan`, `#decision`, or
+`#verify`. Slash commands: `/recall`, `/plan`, `/verify`, `/verify-full`,
+`/progress`, `/remember`, `/curate`.

--- a/config/training/alignment.yaml
+++ b/config/training/alignment.yaml
@@ -5,6 +5,17 @@ max_seq_len: 2048
 num_epochs: 1
 batch_size: 8
 grad_acc_steps: 32
+
+# Declared here (not just on AlignmentConfig) because Hydra runs in struct mode:
+# a key absent from the YAML cannot be set with `training.x=...`, only with the
+# `+training.x=...` append form. Both default to null = current behaviour.
+#
+# max_steps      cap on optimizer steps; null runs the full num_epochs.
+# fixed_seq_len  pad every batch to this length. null = pad to the longest item
+#                in the batch (correct on CUDA). XLA needs a fixed shape or it
+#                recompiles per batch. 256 covers 196 image tokens + a caption.
+max_steps: null
+fixed_seq_len: null
 warmup_ratio: 0.03
 learning_rate: 1.0e-3
 weight_decay: 0.0

--- a/config/training_config.py
+++ b/config/training_config.py
@@ -12,6 +12,13 @@ class AlignmentConfig:
     num_epochs: int = 1
     batch_size: int = 8
     grad_acc_steps: int = 32
+    # None = run the full num_epochs (Modal behaviour, unchanged). An int caps
+    # optimizer steps, which is what makes a bounded TPU smoke stoppable without
+    # killing the tmux session.
+    max_steps: int | None = None
+    # None = pad each batch to its own longest item (CUDA). An int pins the
+    # sequence length, which XLA requires to avoid recompiling per batch shape.
+    fixed_seq_len: int | None = None
     warmup_ratio: float = 0.03
     learning_rate: float = 1e-3
     weight_decay: float = 0.0

--- a/docs/tpu/tpu-capacity-log.md
+++ b/docs/tpu/tpu-capacity-log.md
@@ -1,0 +1,341 @@
+# TPU capacity log -- observed queue times + autonomous fallback policy
+
+> **Provenance.** Entries dated before 2026-07-25 were recorded by sibling projects
+> (`llm-architectures`, `tinyaya-stage2-scale`) running on the **same TRC grant and the
+> same GCP project `ml-pipelines-315702`**.
+>
+> What transfers exactly: quota behaviour, queue times, zone availability, the
+> `IN_USE_ADDRESSES` cap, QR-husk accounting, and spot-churn frequency. These are
+> properties of the grant, not of a model.
+>
+> What does **not** transfer: throughput, step time, and HBM figures. Those belong to
+> other models. Compile-time observations sit in between — the ~14 min cold-boot
+> recompile in §8 is a property of torch_xla on v6e SPMD and is expected to hold here,
+> but it has not been measured for Tiny Aya Vision.
+>
+> The first Tiny Aya Vision TPU run happened 2026-07-25 on a v6e-16; its numbers live in
+> `.claude/orchestration/playbook/baseline-v6e8-siglip-cohere2.md`, not this file.
+
+## 2026-07-26 — large-slice capacity in `europe-west4-a` is a hard wall, not a queue
+
+Five attempts across ~10 hours, zone clean before each (zero QRs, zero nodes, no husks),
+`IN_USE_ADDRESSES` measured at 16/64 so **IP quota was never the binding constraint**:
+
+| Time (UTC) | Profile | Outcome |
+|---|---|---|
+| 2026-07-25 10:46 | `v6e-64-ew4a` | FAILED, code 13, ~5 min |
+| 2026-07-25 ~11:0x | `v6e-32-ew4a` | FAILED, code 13 |
+| 2026-07-25 ~11:2x | `v6e-16-ew4a` | **ACTIVE** — ran a full 2,180-step epoch |
+| 2026-07-26 02:36 | `v6e-64-ew4a` | FAILED, code 13, ~4.5 min |
+| 2026-07-26 02:42 | `v6e-64-ew4a` | FAILED, code 13, ~3.5 min |
+| 2026-07-26 02:46 | `v6e-32-ew4a` | FAILED, code 13, ~4.7 min |
+
+Every failure is byte-identical in shape: `WAITING_FOR_RESOURCES → PROVISIONING →
+SUSPENDING → FAILED`, `{"code": 13, "message": "an internal error has occurred"}`.
+
+**Read `code 13` as "no capacity for this slice size", not as a bug to debug.** The
+service reaches `PROVISIONING` — it accepts the request and starts allocating — then
+withdraws. There is no error text to act on and no queue position to wait in: a failed QR
+does **not** stay queued, it terminates, so "wait longer" is not a strategy. Retrying is
+cheap (~5 min) and occasionally worth one shot, but three v6e-64 attempts and two v6e-32
+attempts across ten hours all failed while v6e-16 succeeded twice.
+
+**Practical rule for this grant, this zone: 16 chips is the ceiling that actually
+provisions.** Anything larger needs either a different zone (cross-region, pays egress
+against the EU bucket) or the v5e family, whose podslice quota does exist here
+(`TPU_LITE_PODSLICE_V5: usage=0 limit=16` in `europe-west4`) but which has 16 GiB HBM per
+chip against v6e's 31.25 — a change the batch config would have to absorb, since the
+measured run already sits at 27.8 GiB/chip.
+
+## 2026-07-25 — Tiny Aya Vision first QR (v6e-64-ew4a)
+
+First provisioning attempt for this project. Recorded here because it corrects a
+claim this file has been carrying.
+
+| Fact | Value |
+|---|---|
+| Profile | `v6e-64-ew4a` (v6e-64, 8 hosts, `europe-west4-a`) |
+| QR | `tayavision-v6e64-qr`, spot |
+| Zone state before | **clean**: zero QRs, zero nodes, no husks |
+| 10:46 | submitted, accepted → `WAITING_FOR_RESOURCES` |
+| 10:48 | `PROVISIONING`, node `CREATING` — capacity was allocated |
+| 10:50 | `SUSPENDING`, `stateInitiator: SERVICE` |
+| 10:51 | `FAILED` — `code 13, "an internal error has occurred"` |
+| 10:52 | husk deleted, zone clean again |
+| **Total** | **~5 min, PROVISIONING → FAILED** |
+
+### This falsifies section 7.1's hypothesis
+
+The 2026-05-05 rows attribute the identical failure — `PROVISIONING → SUSPENDING →
+FAILED in <5 min`, code 13 — to the **`IN_USE_ADDRESSES` cap of 8**: "8-host slice + 8
+IP cap = identical IP quota gate."
+
+That explanation is wrong, or at least no longer holds. Measured at submit time,
+**`europe-west4` `IN_USE_ADDRESSES` was usage 16 / limit 64** — 48 free, against the 8
+an 8-host slice needs. The quota was raised at some point since May. The failure
+reproduced anyway, unchanged, with ample IP headroom.
+
+So `code 13 / "an internal error has occurred"` on a 64-chip v6e spot QR is **not an IP
+quota gate**. It is GCP surfacing something else — most plausibly genuine capacity
+unavailability for a slice that large, reported through an opaque error rather than
+`WAITING_FOR_RESOURCES`. Note the QR reached `PROVISIONING` and the node reached
+`CREATING` first, so it is not a submission-time refusal either: capacity was briefly
+allocated and then taken back by the service.
+
+**Operational consequence:** do not spend time raising IP quota to unblock v6e-64. It is
+already unblocked and still fails. Treat 64-chip v6e spot as un-gettable on this grant
+until proven otherwise, which matches the 2026-07-06 note ("v6e-64 spot proved
+un-gettable on both zones") — that observation was right even though the reason given
+for it was not.
+
+### Other notes from this attempt
+
+- **No `TPU_V6E_*` metric exists in the regional compute quotas at all.** v6e capacity is
+  governed by the TPU API and the TRC grant, not by a compute quota row. "Check the
+  quota" cannot answer "will I get a v6e-64"; only submitting does.
+- The control plane behaved correctly end to end: tarball upload, QR create with
+  self-heal metadata, cross-region check (silent, correctly — this is an EU profile),
+  durability gate satisfied via `SAVE_CKPT_DIR=gs://…`, and forensics captured on
+  failure.
+- `gs://tayavision-eu` was created by `setup_gcp.sh` in this session; it did not exist
+  before.
+
+## 2026-07-08 update
+
+**v6e-8 spot in ew4a is readily gettable** (three same-day QRs went
+WAITING→PROVISIONING→ACTIVE in ~2-5 min each: smoke-scan2, smoke-scan3 after
+quota freed) BUT the 64-chip preemptible quota counts **SUSPENDED/FAILED QR
+husks too**: with 3 arms + 2 dead smokes + 1 failed arm QR still registered,
+new creates 429'd (`TPUV6EPreemptiblePerProjectPerZoneForTPUAPI exhausted`)
+even though only 32 chips were live. Deleting the husks un-jammed launches
+immediately. Same-day preemption observed on a v6e-8 (~2h lifetime,
+smoke-scan) -- plan for spot churn on multi-hour arms (`--resume auto` +
+GCS-staged data tarball keep recovery cheap).
+
+## 2026-07-06 update
+
+Current topology: **v6e-16 spot in `europe-west4-a`** (production) + **v6e-8** (smoke /
+overfit / eval), both from the v6e spot quota. v6e-64 spot proved un-gettable on both
+zones; v4-32 (`us-central2-b`) and v5e are legacy. The fallback policy in section 1 below
+is preserved as the autonomous decision tree for new capacity attempts. See
+[`tpu-trc-allocation.md`](tpu-trc-allocation.md) for the grant table and
+[`tpu-runbook.md`](tpu-runbook.md) for launch.
+
+**Purpose:** Record real queue-wait durations so future sessions can
+make smart autonomous decisions about which TRC slice to try. Updated
+after every QR submission attempt.
+
+The authoritative TRC quota table lives in
+[`docs/tpu-trc-allocation.md`](./tpu-trc-allocation.md); this file
+augments it with *observed* capacity behaviour.
+
+---
+
+## 1. Autonomous fallback policy
+
+This section is **canonical** for zone selection.
+[`tpu-trc-allocation.md`](tpu-trc-allocation.md) owns the grant table and points here
+rather than carrying a second copy of this tree — two copies drift, and a stale fallback
+policy sends you to a zone that costs money.
+
+**Reordered 2026-07-25 for Tiny Aya Vision.** The previous order tried the US zones
+early. That was correct when this policy served a project with `-us` and `-usc1` sibling
+buckets. This project has **one bucket, `gs://tayavision-eu` in `europe-west4`**, so a US
+zone now pays egress on every checkpoint write and every code-tarball pull.
+
+```text
+Start: TRC_PROFILE=v6e-8-eu  (single host, co-located, no external-IP pressure)
+       Wait up to 15 min.
++-- ACTIVE -> proceed.
++-- Still WAITING_FOR_RESOURCES:
+
+1. Run `ops.sh status` and DELETE SUSPENDED/FAILED QR husks first.
+   Husks book quota while dead. Observed 2026-07-08: 3 arms + 2 dead
+   smokes + 1 failed arm 429'd new creates at only 32/64 chips live.
+   Deleting the husks un-jammed launches immediately.
+   Then retry v6e-8-eu once, after a 10 min gap.
++-- Still nothing:
+
+2. Need more chips?
+   -> v6e-64-ew4a  or  v5e-64-ew4b   (both EU, both co-located)
+      CHECK IN_USE_ADDRESSES FIRST -- see 7.1 for the failure it causes.
+      MEASURED europe-west4 2026-07-25: usage=16 limit=64 -> 48 free.
+      An 8-host slice needs 8. NOT a blocker in this region today,
+      contrary to what 7.1's original entry implies.
+      Multi-host still adds PJRT rendezvous to the failure surface.
++-- Not willing, or still nothing:
+
+3. Cross-region. A DELIBERATE CHOICE, not a default.
+   -> v6e-64-ue1d / v5e-64-uc1a / v4-32-uc2b
+      Either accept the egress for a short run, or stand up a
+      region-paired bucket and point SAVE_CKPT_DIR at it.
+      launch_spot.sh warns; it does not block.
++-- Nothing anywhere:
+
+4. Stop and wait. TRC spot has no escalation path, and churning QRs
+   loses your place in the queue. Do NOT auto-delete a QR the user
+   may want left queued.
+```
+
+**Important rules:**
+- Never submit more than one QR at a time. A queued QR still
+  consumes quota; two parallel QRs for the same type will both
+  block.
+- Delete the failed QR before submitting the next one.
+- Record every attempt in section 2 below (timestamp, profile, wait
+  duration, outcome).
+- After 3 consecutive failures in the same day, stop and ask
+  the user rather than burning the retry budget.
+
+## 2. Observed queue durations
+
+| Date | Time (UTC) | Profile | Tier | Wait | Outcome | Notes |
+|---|---|---|---|---|---|---|
+| 2026-05-03 | ~12:00 | v4-64 on-demand (us-central2-b) | on-demand | <5 min | ACTIVE | Original probe run; QR provisioned quickly. |
+| 2026-05-03 | ~14:00 | v4-64 on-demand (us-central2-b) | on-demand | ~0 | ACTIVE | Real composite fsdpv2_lora compile; QR already up from earlier. |
+| 2026-05-05 | 09:23 | v4-32 spot (us-central2-b) | spot | 17+ min | WAITING | Cancelled after 17 min; no progress. Spot v4 in this zone is contended. |
+| 2026-05-05 | 09:46 | v4-64 on-demand (us-central2-b) | on-demand | 10+ min | WAITING/CANCELLED | Cancelled after 10 min per fallback policy timeout; on-demand v4 is also genuinely contended in this zone today. |
+| 2026-05-05 | 12:45 | v5e-64 spot (europe-west4-b) | spot | 2 min PROVISIONING | FAILED | `IN_USE_ADDRESSES limit (8)` -- regional IP quota too small for 8-host v5e-64 with external IPs. Not a TPU capacity issue. Mitigations: (a) request IP quota bump, (b) use `--internal-ips` + Private Google Access + GCS-mirrored dataset. |
+| 2026-05-05 | 13:02 | v6e-64 spot (us-east1-d) | spot | 5 min PROVISIONING | FAILED | Code 13 "an internal error has occurred" -- same failure pattern as v5e-64 ew4b (PROVISIONING -> SUSPENDING -> FAILED in <5 min). 8-host slice + 8 IP cap = identical IP quota gate. |
+| 2026-05-05 | 13:42 | v4-32 spot (us-central2-b) | spot | 3.5 min PROVISIONING | ACTIVE | Retry of the 09:23 attempt with same config + same QR submission. Spot pool cleared in the intervening hours; ACTIVE reached at 13:51 UTC. First successful canary launch of the day. |
+| 2026-05-08 | -- | v4-32 spot (us-central2-b) | spot | hours | SUSPENDED | v4 spot pool reclaimed by other TRC users; QR has been SUSPENDED for several hours with no recovery. Pivoted away. |
+| 2026-05-08 | -- | v6e-8 spot (europe-west4-a) | spot | ~4:44 | ACTIVE | Single-host (8 chips), 32 GiB HBM/chip. ACTIVE within 5 min from QR submission. Iter 13b (run `zd42n7di`) reached 20 steps + canonical save in 23.3 min wall. |
+| 2026-05-09 | 15:25 | v6e-8 spot (europe-west4-a) | spot | ~3 min to ACTIVE | ACTIVE / COMPLETED | Iter 24h production retry. QR reached ACTIVE at 15:28 UTC; run `7rrjupc7` completed 5000/5000 steps at 2026-05-10T01:47:24Z and uploaded `step_005000_final` (8 objects, 2.37 GiB). |
+| 2026-05-13 | ~11:30 | v6e-8 spot (europe-west4-a) | spot | immediate preemptions / capacity retry | FAILED | Phase 4 `opt-4-depth32` first attempts hit spot preemption and then QR capacity error code 8. User chose to keep retrying same zone. |
+| 2026-05-13 | ~12:00 | v6e-8 spot (europe-west4-a) | spot | ~few min to ACTIVE | ACTIVE / COMPLETED | Relaunched Phase 4 with `REPO_TARBALL_GS_URI=gs://tinyaya-stage2-eu/code/phase4-depth32-20260513T120005Z.tar.gz`; startup avoided private GitHub clone and W&B `i15igq8d` completed 300/300 steps with exit 0. |
+
+*(Update this table after every attempt.)*
+
+## 3. Per-profile heuristics
+
+Based on the limited data so far:
+
+| Profile | Expected wait | Confidence | Notes |
+|---|---|---|---|
+| v4-64 on-demand (uc2b) | 0-15 min | LOW (1 success, 1 pending) | Succeeds when no other TRC user in this zone has the on-demand quota occupied. |
+| v6e-8 spot (ew4a) | 0-10 min when capacity is available; retry after preemption/capacity code 8 | HIGH | Current validated production/optimization profile. One host = one external IP, fits quota, no multi-host rendezvous. |
+| v4-32 spot (uc2b) | 0-20 min, hour-by-hour | MEDIUM (1 fail at 09:23, 1 success at 13:42) | Legacy fallback. Spot pool clears on a sub-hour timescale. Cancel-and-retry within a few hours is a valid strategy. 4 hosts = 4 IPs, fits the 8-IP regional cap easily. |
+| v5e-64 spot (ew4b) | 2 min to PROVISIONING then FAILED | LOW (1 IP-quota fail) | Hits `IN_USE_ADDRESSES` regional quota (8) because 8-host slice needs 8 external IPs. Use `--internal-ips` (requires Private Google Access on subnet + GCS-mirrored dataset) or request IP quota bump. |
+| v5e-64 spot (uc1a) | unknown | NONE | Never tried. |
+| v6e-64 spot (ue1d) | 5 min PROVISIONING then FAILED | LOW (1 IP-quota fail) | Same root cause as v5e-64: 8-host slice + regional 8-IP cap. Code 13 ("internal error") instead of explicit IP-quota message, but identical failure pattern and timing. |
+
+**Actionable insight:** v5e-64 in europe-west4-b is the strongest
+fallback candidate because (a) 64 chips is the biggest spot grant we
+have, (b) europe region may have lower TRC competition than us-central2,
+(c) the canary config is already retuned for v5e HBM/chip constraints.
+Try it THIRD (after on-demand v4 and spot v4).
+
+## 4. Session checklist for autonomous QR launch
+
+Before submitting any QR, a droid session must:
+
+- [ ] `bash scripts/tpu/ops.sh preflight` -- gcloud auth, `.env` keys, entrypoint,
+  bucket reachability. **`HF_TOKEN` is not optional**: `CohereLabs/tiny-aya-*` is gated
+  and the run cannot start without it.
+- [ ] Read this file for the latest observed wait times.
+- [ ] Read [`tpu-trc-allocation.md`](tpu-trc-allocation.md) for the quota table.
+- [ ] `bash scripts/tpu/ops.sh status` -- confirm no existing QR, and **delete
+  SUSPENDED/FAILED husks**; they book quota while dead.
+- [ ] Pick the first profile from the decision tree in section 1 (starts at
+  `v6e-8-eu`).
+- [ ] Submit the QR, start a 15-min poller.
+- [ ] If ACTIVE: proceed with `TAYAVISION_ENTRYPOINT=scripts/tpu/tpu_smoke.py`.
+  **Not a training entrypoint** -- `pipeline/train_*.py` is DDP + CUDA and does not run
+  on TPU yet. See `.claude/orchestration/SPEC.md` §9.
+- [ ] If still WAITING: delete the QR, advance to the next branch, update section 2
+  with the observed wait.
+- [ ] After 3 failures: stop and ask the user.
+- [ ] When done: `bash scripts/tpu/ops.sh delete`. A live slice bills whether or not
+  anything is running on it.
+
+## 5. Cross-references
+
+- [`tpu-trc-allocation.md`](tpu-trc-allocation.md) -- authoritative TRC quota table.
+- [`tpu-runbook.md`](tpu-runbook.md) -- the operator command sequence.
+- `scripts/tpu/launch_spot.sh` -- the `TRC_PROFILE`-aware launch wrapper; warns on
+  cross-region profiles against the single `gs://tayavision-eu` bucket.
+- `scripts/tpu/ops.sh` -- `preflight`, `status`, `tail-logs`, `attach`, `delete`.
+- `.claude/orchestration/SPEC.md` -- the run loop, the T3 recycle policy, and §9 on
+  what does not work yet.
+- `.claude/agents/tpu-diagnoser.md` -- signature to tier classification.
+- .factory/memories.md -- decision entry for the fallback policy.
+
+## 6. Maintenance
+
+Prune entries older than 90 days from section 2 during the monthly
+archive-progress cycle. The heuristics in section 3 should be updated
+whenever a new profile is tried (success or failure).
+
+## 7. Known issues + workarounds
+
+### 7.1 `IN_USE_ADDRESSES limit` on v5e/v6e slices
+
+**Symptom:** QR transitions `WAITING_FOR_RESOURCES` -> `PROVISIONING`
+-> `SUSPENDING` -> `FAILED` within 2 minutes with error
+`You have reached IN_USE_ADDRESSES limit. [EID: ...]`.
+
+**Cause:** Regional Compute Engine `IN_USE_ADDRESSES` quota is **8**
+in every region we have TPU quota in (europe-west4, us-central1,
+us-central2). v5litepod-64 (8 hosts) and v6e-64 (8 hosts) want one
+external IP per host = 8 IPs total, hitting the limit exactly.
+v4-64 (4 hosts? or 8 hosts depending on topology) is right at the
+edge. Even momentary other usage (a Cloud Build worker, a Compute
+VM) pushes us over.
+
+**Workaround A (recommended):** Use `INTERNAL_IPS=1` with
+`launch_qr.sh` (requires the `--internal-ips` flag plumbing added
+2026-05-05). Prerequisites:
+  1. Private Google Access enabled on `default` subnet in the target
+     region (`gcloud compute networks subnets update default
+     --region=<R> --enable-private-ip-google-access`).
+  2. Dataset mirrored to `gs://tinyaya-stage2-eu/encoded/` so the
+     startup script can pull it via GCS instead of HF Hub.
+  3. Code tarball already lives in GCS (already done: `code/tinyaya-repo-hot.tar.gz`).
+
+**Workaround B:** Request a regional IP quota bump from GCP support
+(typical turnaround 1-3 business days).
+
+**Workaround C:** Pick a smaller slice (v4-32 = 4 hosts = 4 IPs;
+stays under quota) at the cost of less data parallelism.
+
+### 7.2 GCP quota increase request (drafted 2026-05-05)
+
+A quota-increase email was drafted for the user to send to GCP
+(both via the IAM & Admin console and to
+`cloud-tpu-trc-support@google.com`). Request: raise
+`IN_USE_ADDRESSES` from 8 to 32 in europe-west4, us-central1,
+us-east1, and us-central2. Draft is at
+`_artifacts/gcp-quota-increase-request.md`. Until the quota is
+bumped, v5e-64 and v6e-64 slices remain blocked; v4-32 and v4-64
+stay viable (4 hosts = 4 IPs = fits cap).
+
+## 8. Compile time observations
+
+Recording how long XLA compile took on each successful run, so the
+fallback policy can budget realistic wall time before declaring a
+canary failed.
+
+| Date | Slice | Strategy | scan_layers state | Forward step 1 | Backward step 1 | Notes |
+|---|---|---|---|---|---|---|
+| 2026-05-03 | v4-64 on-demand uc2b | fsdpv2_lora | (probe only, no training) | n/a | n/a | Per `.factory/memories.md` 2026-05-03 entries; 25+ min compile feared, never completed mid-session. |
+| 2026-05-05 | v4-32 spot uc2b | fsdpv2_lora | TypeError -> manual loop | ~20 min | **~4h 25min** | scan_layers fallback was triggered on every layer call (40+ TypeError lines per step). Backward unrolled 36 CohereDecoderLayer + 6 MoshiDecoderLayer instances into HLO; XLA optimisation passes spent multi-hour wall time before producing executable. Process died at 8h 24min wall (likely supervisor timeout or OOM-kill); supervisor loop restarted from scratch with no XLA cache reuse. |
+
+**Lesson:** the documented "25+ min compile" budget assumes
+`scan_layers` is taking the fast path. With the manual-loop fallback
+the compile is 5-10x longer. Until the `_KwargBoundLayer` patch in
+`.factory/memories.md` 2026-05-05 "scan_layers TypeError" is applied,
+do not budget less than 5h wall time for first-canary compile.
+
+
+## v6e-16 multi-host envelope (hardening probes, 2026-07-14)
+
+- Steady step (global batch 32 = b2/chip × 16, grad-ckpt ON, chunk 100):
+  **1.79–1.85 s/step**; HBM **25.7–27.8 / 31.25 GiB** with train+val graphs.
+- Capacity ladder: **b4/chip OOMs** — program arena wants 18.99 G with 18.42 G
+  free (resident weights+optimizer ≈ 12.8 G/chip). The locked b2 recipe sits
+  just under half the activation envelope.
+- Step-time levers all neutral (probes): grad-ckpt OFF, depth_chunk 300,
+  flash-attention ON. Persistent XLA compile cache: nondeterministic keys on
+  torch_xla 2.9 v6e SPMD — never hits; ~14 min recompile per cold boot.
+- Val×4 (`val_per_chip_batch: 8`, same 3200-sample gate): cycle ~210 s → ~41–60 s
+  measured warm on the rehearsals.

--- a/docs/tpu/tpu-runbook.md
+++ b/docs/tpu/tpu-runbook.md
@@ -1,0 +1,193 @@
+# TPU Runbook — Tiny Aya Vision on Cloud TPU (torch_xla)
+
+Operational guide for provisioning and driving a TRC Cloud TPU slice for Tiny Aya Vision.
+Companions: [`tpu-trc-allocation.md`](tpu-trc-allocation.md) (the grant),
+[`tpu-capacity-log.md`](tpu-capacity-log.md) (observed capacity + the fallback tree), and
+`.claude/orchestration/` (why any of this is shaped the way it is).
+
+> ## Read this first
+>
+> **No training entrypoint runs on TPU yet.** `pipeline/train_alignment.py`,
+> `train_instruct.py`, and `train_multilingual.py` are DDP + CUDA — `torch.autocast("cuda", …)`,
+> `torch.device(f"cuda:{local_rank}")`, `DistributedDataParallel`, `DistributedSampler`.
+> None of that runs under torch_xla.
+>
+> What this runbook gives you today is **provisioning and supervision**: a slice, code
+> delivery, dependency install, a launched-and-watched process, and automatic recovery
+> from spot preemption. The default entrypoint is `scripts/tpu/tpu_smoke.py`, which
+> exercises every one of those layers and reports device count, mesh, HBM, and XLA
+> compile counters on real silicon.
+>
+> The remaining work is a `src/backend/` seam. See `.claude/orchestration/SPEC.md` §9.
+> **Do not edit `pipeline/train_*.py` to "just add TPU support" inline** — that breaks the
+> Modal/GPU path, which is where every published result comes from.
+
+## Hardware & zones
+
+The grant is shared with sibling projects on the same GCP project
+(`ml-pipelines-315702`). Full table in [`tpu-trc-allocation.md`](tpu-trc-allocation.md).
+
+| Profile | Topology | Zone | Runtime | Bucket |
+|---|---|---|---|---|
+| **`v6e-8-eu`** (default) | 1 host × 8 chips | `europe-west4-a` | `v2-alpha-tpuv6e` | co-located |
+| `v6e-64-ew4a` | 8 hosts × 8 chips | `europe-west4-a` | `v2-alpha-tpuv6e` | co-located |
+| `v5e-64-ew4b` | 16 hosts × 4 chips | `europe-west4-b` | `v2-alpha-tpuv5-lite` | co-located |
+| `v6e-64-ue1d`, `v5e-64-uc1a`, `v4-32-uc2b` | — | US zones | — | **cross-region** |
+
+- TRC v6e is **spot-only**. 31.25 GiB usable HBM per chip; the model is ~7.5 GB in bf16.
+- **One bucket: `gs://tayavision-eu` (europe-west4).** Only the three EU profiles are
+  co-located; anything else pays egress on every checkpoint write.
+- **Multi-host external-IP headroom: verify, do not assume.** A sibling project hit an
+  `IN_USE_ADDRESSES` cap of 8 in this grant (capacity log §7.1), which would block any
+  8-host slice. **Measured in `europe-west4` on 2026-07-25: usage 16, limit 64** — 48
+  free, so an 8-host v6e-64 fits. The cap was either raised or was never 8 in this
+  region. Check before blaming it:
+  `gcloud compute regions describe europe-west4 --format='json(quotas)'`.
+  `v6e-8-eu` is single-host and sidesteps both the IP question and PJRT rendezvous —
+  still the right default while the TPU path is being brought up.
+- **SUSPENDED/FAILED QR husks still book quota.** Delete them before blaming capacity.
+
+## Prerequisites
+
+```bash
+bash scripts/tpu/ops.sh preflight
+```
+
+Checks gcloud auth, the four `.env` keys, entrypoint existence, and bucket reachability.
+It prints presence, never values.
+
+`.env` at the repo root is **required** and is gitignored. Copy `.env.example` and fill:
+
+| Key | Absent → |
+|---|---|
+| `HF_TOKEN` | **The run cannot start.** `CohereLabs/tiny-aya-{base,global}` is a gated repo. |
+| `WANDB_API_KEY` | Trains, but is unobservable — `no WANDB_API_KEY found` in the log. |
+| `NTFY_TOPIC` | Self-healing still works, silently. Tolerable for a foreground smoke, not overnight. |
+| `PROJECT_ID` | Defaults to `ml-pipelines-315702`. |
+
+The tarball ships `.env` to the VM. **There is no git clone anywhere in this flow** —
+that is the only way a gated-repo token reaches the worker.
+
+> Append to `.env` with `printf '\n%s\n'`, never `echo X >>`. A file with no trailing
+> newline silently concatenates the new key onto the previous line, and the variable
+> then does not exist. That cost a full day of dropped alerts on a sibling project.
+
+## One-time bootstrap
+
+```bash
+bash scripts/tpu/setup_gcp.sh    # enable APIs, create gs://tayavision-eu, grant IAM
+```
+
+Idempotent. Creates exactly one bucket, in `europe-west4`.
+
+## Provision and launch
+
+```bash
+TRC_PROFILE=v6e-8-eu bash scripts/tpu/launch_spot.sh
+```
+
+`launch_spot.sh` → `launch_qr.sh` tars the working tree (**including the gitignored
+`.env`**), uploads it to `gs://tayavision-eu/code/`, and creates the queued resource with
+`startup_script.sh` as metadata. On boot each host installs uv, pulls and extracts the
+pinned tarball, runs `uv sync` (CPU torch) + `uv pip install torch_xla[tpu]`, resolves the `libpython3.12.so.1.0` link that
+`torch_xla`'s `_XLAC.so` needs, and launches the entrypoint in a `tmux` session teed to
+`/tmp/train.log`.
+
+Knobs travel as VM metadata:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `TAYAVISION_ENTRYPOINT` | `scripts/tpu/tpu_smoke.py` | Repo-relative path passed to `uv run python -u` |
+| `TAYAVISION_HYDRA_OVERRIDES` | `""` | Appended verbatim, e.g. `vision=siglip llm=base wandb.project=tayavision-tpu` |
+| `TAYAVISION_RESUME` | `auto` | Resume from the latest checkpoint under `SAVE_CKPT_DIR` |
+| `TPU_STRATEGY` | `replicated` | `replicated` \| `fsdpv2_lora` \| `fsdpv2` \| `auto` |
+| `SAVE_CKPT_DIR` | unset | **Set this to a `gs://` path** for anything long-running — see below |
+
+This repo is Hydra-configured, so the orchestration does not invent a dozen env
+overrides: it carries one override string and appends it to the launch line.
+
+### Keep the QR alive across preemption
+
+```bash
+tmux new -d -s qrwatch-tayavision 'bash scripts/tpu/qr_watch.sh'
+```
+
+Polls the queued resource every 300s; on `SUSPENDED`/`FAILED` it captures forensics,
+checks for a quota-class abort, deletes the QR, and resubmits the identical launch env.
+Bounded by `MAX_RESUBMITS=20` plus a cooldown.
+
+The session name is **suffixed** deliberately — the same workstation runs a plain
+`qrwatch` for `llm-architectures`, and `tmux new -s qrwatch` against an existing session
+attaches to the wrong one, leaving this project's QR silently unwatched.
+
+> **`qr_watch.sh` refuses to auto-recycle unless `SAVE_CKPT_DIR` is a `gs://` URI.**
+> A recycled node whose checkpoints went to node-local disk resumes from step 0 and
+> re-pays ~14 minutes of cold-boot XLA compile to redo work it already did — up to twenty
+> times, silently. Without durable checkpoints it degrades to notify-only and says so in
+> the push event.
+
+## Observe and control
+
+```bash
+bash scripts/tpu/ops.sh status       # QR + node state
+bash scripts/tpu/ops.sh tail-logs    # follow /tmp/train.log on worker 0
+bash scripts/tpu/ops.sh attach       # sudo tmux attach -t train (root-owned)
+bash scripts/tpu/ops.sh ssh          # shell on worker 0
+bash scripts/tpu/ops.sh delete       # tear down the QR (stops billing)
+```
+
+**Compile is not a hang.** The persistent XLA cache has nondeterministic keys on v6e SPMD
+and effectively never warm-hits, so **~14 minutes of recompile on a cold boot is normal**.
+Judge a stall by the `met.metrics_report()` compile-cause counter, not by elapsed time.
+The `tpu-watchdog` agent uses a 20-minute threshold for exactly this reason.
+
+When reading logs, take status markers from the **tail** and fetch repeating per-step
+lines in a separate query. Piping both through one `head -N` truncates the rare marker
+behind N repeats of the noisy one; that bug hid a completed run for an hour on a sibling
+project.
+
+## Redeploy without reprovisioning
+
+```bash
+bash scripts/tpu/deploy_tarball.sh
+```
+
+Tars, uploads, pulls on `--worker=all`, and relaunches tmux `train` everywhere. This is
+the T2 action in the recovery ladder; it never touches the queued resource.
+
+**A redeploy costs a full recompile here** (~14 min), unlike the ~1 minute it costs on a
+JAX sibling. Batch your fixes — two T2s in a row for two one-line patches is half an hour
+of silicon spent compiling.
+
+## Gotchas
+
+- **`torch_xla` import fails with `ImportError: libpython3.12.so.1.0`.** `_XLAC.so`
+  dynamically links libpython, which uv keeps outside the default loader path.
+  `startup_script.sh` exports `LD_LIBRARY_PATH` from the uv Python root; if this fires,
+  that block was dropped.
+- **SPMD is a single process.** `DistributedSampler` must be **off**. Left on, one process
+  holds a 1/N shard, trains on 1/N of the dataset, and reports nothing wrong.
+- **Never wrap `Cohere2DecoderLayer` in an FSDPv2 auto-wrap policy.** 36 per-layer wraps
+  produce 36 bf16 reduce-scatters and hit a known NaN (pytorch/xla #8591 / #8778); FSDPv2
+  has no `fp32_reduce_scatter`. Observed on a sibling project with **this same backbone**.
+  On this model `replicated` fits comfortably and sidesteps it — Phase 1 trains ~11.5M
+  params of ~3.75B.
+- **MoonViT is not TPU-eligible unbucketed.** It emits a variable token count per image,
+  so XLA compiles a new program per distinct shape. SigLIP's fixed 196 tokens is the TPU
+  path.
+- **A killed `gcloud ssh` does not kill the remote command.** A local `timeout` orphans
+  it. Long remote work goes in a detached session with an explicit liveness check.
+- **`which uv` is empty under sudo.** Use `/root/.local/bin/uv` in root contexts.
+- **TRC is a free grant.** Never delete or reprovision a slice without intent, and delete
+  husks you are done with — they book quota for everyone on the project.
+
+## Where to look when something breaks
+
+| Symptom | First thing to open |
+|---|---|
+| Anything at all | `.claude/agents/tpu-diagnoser.md` — signature → tier → action |
+| What to do at a tier | `.claude/orchestration/playbook/tier-definitions.md` |
+| QR state / preemption | `/tmp/qr_watch_tayavision.log`, then `ops.sh status` |
+| Run behaviour | worker 0 `/tmp/train.log`, tail-first |
+| Capacity refusals | [`tpu-capacity-log.md`](tpu-capacity-log.md) §7.1 |
+| "Should this even work yet?" | `.claude/orchestration/SPEC.md` §9 |

--- a/docs/tpu/tpu-trc-allocation.md
+++ b/docs/tpu/tpu-trc-allocation.md
@@ -1,0 +1,168 @@
+# TRC TPU allocation -- authoritative record
+
+## 2026-07-25 update (Tiny Aya Vision)
+
+**The grant is shared across sibling projects.** The same TRC allocation and the same GCP
+project back `llm-architectures` (nanoGPT-JAX) and `tinyaya-stage2-scale` (speech), which
+is why the quota rows below have history attached to models that are not this one. The
+grant table is authoritative; the per-project usage notes are not.
+
+For Tiny Aya Vision specifically:
+
+- **Default profile `v6e-8-eu`** — single host, 8 chips, `europe-west4-a`. Single-host
+  means no PJRT rendezvous and no external-IP pressure (see the `IN_USE_ADDRESSES`
+  caveat in [`tpu-capacity-log.md`](tpu-capacity-log.md), which blocks every 8-host
+  slice in this grant).
+- **Checkpoints and code tarballs → `gs://tayavision-eu` (europe-west4).** One bucket,
+  deliberately. Every other zone in this grant is therefore cross-region for this
+  project — see "Bucket co-location" below before picking a non-EU profile.
+- Prior observations recorded here against v6e-16 / v6e-64 came from sibling projects.
+  The **quota and capacity behaviour transfers exactly** (same grant, same project); the
+  throughput and memory numbers do not (different models).
+
+**Status:** Active
+**Captured:** 2026-05-05
+**Recipient:** `<TRC grant recipient>`
+**GCP project:** `ml-pipelines-315702`
+**Grant duration:** 90 days (free Cloud TPU usage; non-TPU GCP services
+still billed; Google may reclaim capacity at any time)
+**Source:** TRC welcome email from `trc-support@google.com` (subject
+"You have access to free Cloud TPUs"), pasted by the user on
+2026-05-05 and archived verbatim in this document.
+
+This file is the **single source of truth** for which TPU types,
+zones, and tiers we are entitled to.
+
+---
+
+## 1. Allocation table
+
+| Quantity | TPU type | Zone | Tier |
+|---:|---|---|---|
+| 32 chips | Cloud TPU v4 | `us-central2-b` | **spot** |
+| 32 chips | Cloud TPU v4 | `us-central2-b` | **on-demand** |
+| 64 chips | Cloud TPU v5e | `europe-west4-b` | spot |
+| 64 chips | Cloud TPU v5e | `us-central1-a` | spot |
+| 64 chips | Cloud TPU v6e | `europe-west4-a` | spot |
+| 64 chips | Cloud TPU v6e | `us-east1-d` | spot |
+
+The dual v4 lines in `us-central2-b` are independent quotas: 32 chips
+of on-demand AND 32 chips of spot in the same zone.
+`v6e-8-eu` is a smaller single-host slice requested against the v6e
+spot capacity in `europe-west4-a`; it is not a separate TRC grant row.
+
+### Profile shorthands
+
+`scripts/tpu/launch_spot.sh` accepts the following `TRC_PROFILE`
+values, each mapping to a single row above:
+
+| `TRC_PROFILE` | TPU type passed to `gcloud` | Zone | Hosts | Bucket | Notes |
+|---|---|---|---|---|---|
+| **`v6e-8-eu`** (default) | `v6e-8` | `europe-west4-a` | 1 | co-located | Single-host 8-chip slice. No rendezvous, no external-IP pressure. The only profile that is unblocked today. |
+| `v6e-64-ew4a` | `v6e-64` | `europe-west4-a` | 8 | co-located | Newest gen; needs `v2-alpha-tpuv6e`. Blocked on `IN_USE_ADDRESSES`. |
+| `v5e-64-ew4b` | `v5litepod-64` | `europe-west4-b` | 16 | co-located | Largest v5e slice. Same region as the bucket. Blocked on `IN_USE_ADDRESSES`. |
+| `v6e-64-ue1d` | `v6e-64` | `us-east1-d` | 8 | **cross-region** | Same as `-ew4a`, US zone. Egress on every checkpoint write. |
+| `v5e-64-uc1a` | `v5litepod-64` | `us-central1-a` | 16 | **cross-region** | Same chip family as `-ew4b`, US zone. Egress. |
+| `v4-32-uc2b` | `v4-32` | `us-central2-b` | 4 | **cross-region** | Legacy v4 fallback; same zone as the on-demand v4 quota. Egress. |
+
+The on-demand v4 quota does not need a profile here -- it is already
+the default of `scripts/tpu/launch_qr.sh` (no `--spot`).
+
+### Bucket co-location
+
+Tiny Aya Vision uses **one bucket, `gs://tayavision-eu` in `europe-west4`.** Only the
+three `europe-west4-*` profiles are co-located with it.
+
+A cross-region profile still works, but every checkpoint write and every code-tarball
+pull crosses regions. On a 3.35B backbone with a projector checkpoint per save interval
+that is not a rounding error, and TRC covers the TPU, not the egress.
+
+So: exhaust EU capacity before reaching for a US zone. If a US zone is genuinely the only
+capacity available, that is a deliberate call with two honest options — accept the egress
+for a short run, or stand up a second region-paired bucket and point `SAVE_CKPT_DIR` at
+it. `scripts/tpu/launch_spot.sh` prints a warning rather than blocking; it will not
+decide this for you.
+
+## 2. Important caveats (verbatim from the email)
+
+> This free 90-day trial is only available for new Cloud TPUs you
+> create in the zones listed above. To avoid charges, please be sure
+> to create your Cloud TPUs in the appropriate zone.
+
+> While your Cloud TPUs are free, you'll still be charged for the
+> rest of the GCP services you use. If you have a new account, Google
+> Cloud's $300 USD introductory credit may completely offset these
+> costs, and you can minimize costs even more by utilizing the new
+> Cloud TPU VM architecture.
+
+> Please note that demand for Cloud TPUs is high, so we can't
+> guarantee you'll get to use all of your TPU quota. Google reserves
+> the right to reclaim TRC quota and TRC Cloud TPU capacity at any
+> time.
+
+> If you have access to both on-demand and preemptible quotas, we
+> recommend preferring on-demand and falling back to preemptible
+> if/when on-demand is not available.
+
+> If you have access to v2-8 and/or v3-8 quotas, please be aware
+> that these individual devices cannot be used in pod configurations.
+> *(Not applicable to this grant -- no v2/v3 quotas.)*
+
+> If you encounter an error message indicating that your quota is
+> exhausted, confirm that you have deleted any unused Cloud TPUs
+> and/or Queued Resources that may still be consuming quota.
+
+## 3. How to pick a zone (decision tree)
+
+**The decision tree is canonical in
+[`tpu-capacity-log.md`](tpu-capacity-log.md) §1**, not here. That file owns observed
+capacity behaviour and the fallback policy derived from it; this file owns the grant.
+Keeping one copy is deliberate — a fallback tree that drifts from the observed capacity
+log sends you to a zone that costs egress or is blocked outright.
+
+**Operational default for Tiny Aya Vision:** `v6e-8-eu`. It is the only profile not
+blocked by the external-IP cap, it is co-located with `gs://tayavision-eu`, and
+single-host removes rendezvous from the failure surface entirely — which matters while
+the TPU path is still being brought up. Set `TRC_PROFILE` explicitly for anything else.
+
+## 4. Program requirements (we accepted these)
+
+Per the welcome email, TRC participants are expected to:
+
+- Share TRC-supported research with the world (peer-reviewed
+  publications, open-source code, blog posts, or other means).
+- Share detailed feedback with Google to help improve the TRC
+  program and the underlying Cloud TPU platform.
+- Conduct research in accordance with the Google AI Principles.
+- Accept Google's Terms and Conditions.
+- Acknowledge that the participant's information will be used
+  in accordance with Google's Privacy Policy.
+
+Acknowledged. Outputs from this repo (code, blog post, eval results)
+are intended to satisfy the publication requirement.
+
+## 5. Support
+
+- Email: `trc-support@google.com`.
+- Discord: `#tpu-research-cloud` channel on the Google Developer
+  Community Discord server.
+- Recommended reading: PyTorch/XLA performance debugging blog series (Parts I-III).
+
+## 6. Footer (verbatim from the email)
+
+> Google LLC 1600 Amphitheatre Parkway, Mountain View, CA 94043
+>
+> This email was sent to `<TRC grant recipient>` to update you
+> about important information regarding your Google Cloud Platform
+> account.
+
+## 7. Cross-references
+
+- [`tpu-runbook.md`](tpu-runbook.md) -- current launch / resume / staging.
+- [`tpu-capacity-log.md`](tpu-capacity-log.md) -- observed queue times, the
+  `IN_USE_ADDRESSES` blocker, and the autonomous fallback policy.
+- `scripts/tpu/launch_spot.sh` -- materialises the `TRC_PROFILE` shorthands into
+  `gcloud` flags and warns on cross-region profiles.
+- `.claude/orchestration/CONTROL_PLANE.md` -- names this file as the owner of "TRC quota
+  + zone grants". Live capacity is owned by the capacity log, not here.
+- `.claude/memories.md` -- durable decisions, including the single-bucket choice.

--- a/docs/tpu_alignment_handoff_2026-07.md
+++ b/docs/tpu_alignment_handoff_2026-07.md
@@ -431,7 +431,84 @@ NaN that would look like a hardware bug.
 
 ---
 
-## 9. Full provenance
+## 9. Decommission plan
+
+The TPU slice is **already deleted** (2026-07-26): zero queued resources, zero nodes in
+`europe-west4-a`. TPU billing has stopped. What remains is `gs://tayavision-eu`, ~963 MiB.
+
+### Step 1 — delete `code/` and rotate the tokens (do this first)
+
+```bash
+gcloud storage rm -r gs://tayavision-eu/code
+```
+
+**45 tarballs, 566 MiB, and every one contains a live `.env`.** Verified, not assumed:
+
+```
+$ gcloud storage cat gs://tayavision-eu/code/latest.tar.gz | tar tzf - | grep '\.env$'
+./.env
+```
+
+That was deliberate and correct while the slice existed — `CohereLabs/tiny-aya-*` are gated,
+there is no git clone in the TPU flow, so the tarball was the only channel credentials had
+(see `.env.example` and `scripts/tpu/_lib.sh:make_code_tarball`). With the slice gone it is
+only exposure: 45 copies of a live `HF_TOKEN` and `WANDB_API_KEY` at rest.
+
+The bucket reports **no explicit `publicAccessPrevention` and no uniform bucket-level
+access** — that does not mean it is public, but it does mean nothing is enforcing that it
+stays private.
+
+**Rotate `HF_TOKEN` and `WANDB_API_KEY` regardless of whether you delete the bucket.**
+Deleting the objects does not un-exfiltrate anything that may already have been read, and
+rotation is cheap.
+
+The code itself is not lost: it is on the `tpu` branch. The tarballs are snapshots of it.
+
+### Step 2 — decide about `checkpoints/` (396.5 MiB)
+
+```bash
+# Inspect before removing anything
+gcloud storage ls -r 'gs://tayavision-eu/checkpoints/**'
+```
+
+`v6e16-align-01/e93fe1cd-.../checkpoint_4360.pt` is **the trained projector** — the single
+scientific output of this work. A local copy exists at
+`outputs/tpu-align-v6e16-2026-07-25/checkpoint_4360.pt` (67 MB, gitignored, verified
+loadable), so deleting the bucket copy is survivable but leaves exactly one copy on one
+laptop.
+
+Recommended: **keep** `v6e16-align-01/`, or move it somewhere long-lived (a HF repo, or
+`gs://` in a project you are keeping) before deleting. The seven sibling run-id directories
+under that prefix hold only `config.json` from failed attempts and can go:
+
+```bash
+# Keeps the one directory that matters, removes the debris
+gcloud storage ls gs://tayavision-eu/checkpoints/v6e16-align-01/ \
+  | grep -v e93fe1cd-684c-4c0f-925b-ad9eeb38ddf1 \
+  | xargs -r -I{} gcloud storage rm -r {}
+```
+
+### Step 3 — the bucket itself
+
+Only once steps 1 and 2 are settled:
+
+```bash
+gcloud storage rm -r gs://tayavision-eu     # contents
+gcloud storage buckets delete gs://tayavision-eu
+```
+
+The bucket is in project `ml-pipelines-315702` and is **not** part of the TRC grant, so it
+does not disappear on its own — it will keep costing storage until deleted. At ~963 MiB
+that is cents per month, so there is no urgency on cost grounds; the urgency is entirely
+step 1.
+
+### What is already done
+
+- TPU slice and queued resource deleted; zone verified clean.
+- Trained weights copied locally and verified loadable.
+- All code committed to branch `tpu` and pushed; PR #76 open.
+
+## 10. Full provenance
 
 | | |
 |---|---|

--- a/docs/tpu_alignment_handoff_2026-07.md
+++ b/docs/tpu_alignment_handoff_2026-07.md
@@ -1,0 +1,456 @@
+# Tiny Aya Vision on TPU — run record and resume guide
+
+**Written 2026-07-26, the last day of the TRC grant.** Everything below was measured on
+real hardware, not estimated. Where something is unverified it says so.
+
+The headline: **Phase 1 alignment completed a full epoch on a Cloud TPU v6e-16 and the
+trained projector is safe in GCS.** The `src/backend/` seam now lets the same
+`pipeline/train_alignment.py` run on either CUDA/DDP or torch_xla/SPMD.
+
+---
+
+## 0. TL;DR
+
+| | |
+|---|---|
+| **Result** | Full 1-epoch alignment, 2,180 optimizer steps, loss **9.053 → 2.367** |
+| **Hardware** | v6e-16 (4 hosts x 4 chips), `europe-west4-a`, spot |
+| **Wall clock** | **59 min 08 s** |
+| **Trained weights** | `gs://tayavision-eu/checkpoints/v6e16-align-01/e93fe1cd-684c-4c0f-925b-ad9eeb38ddf1/checkpoint_4360.pt` |
+| **Local copy** | `outputs/tpu-align-v6e16-2026-07-25/checkpoint_4360.pt` (67 MB, gitignored) |
+| **W&B** | https://wandb.ai/cataluna84/tayavision-tpu/runs/e93fe1cd684c4c0f925bad9eeb38ddf1 |
+| **Effective batch** | **256 — deliberately identical to the Modal GPU baseline** |
+| **Biggest caveat** | **None of the code is committed.** See section 5. |
+
+The checkpoint is **backend-portable**: all tensors are CPU-resident bf16, so it loads on
+CUDA with no conversion. Verified by loading it (section 1).
+
+---
+
+## 1. Artifacts — what exists and where
+
+### The trained projector
+
+```
+gs://tayavision-eu/checkpoints/v6e16-align-01/e93fe1cd-684c-4c0f-925b-ad9eeb38ddf1/
+    checkpoint_1000.pt   checkpoint_2000.pt   checkpoint_3000.pt
+    checkpoint_4000.pt   checkpoint_4360.pt   <- final, end of epoch
+    config.json
+```
+
+Filenames count **micro-steps**; 4360 micro-steps = 2,180 optimizer steps at
+`grad_acc_steps=2`. The bucket lives in GCP project `ml-pipelines-315702` and is **not**
+part of the TRC grant, so it outlives the grant — but it is also billable storage, so
+confirm it still exists before relying on it.
+
+Verified contents of `checkpoint_4360.pt`:
+
+| Field | Value |
+|---|---|
+| `step` | 4360 |
+| `lr_scheduler.last_epoch` | 2180 (consistent with the above) |
+| `projector` | 6 tensors, **11,547,648 params** — matches the documented ~11.5 M |
+| dtype / device | **bf16 / cpu** — portable to CUDA as-is |
+| Shapes | `layernorm.{weight,bias}` (4608,), `linear_1` (2048,4608), `linear_2` (2048,1024) |
+| Sanity | mean 0.00040, std 0.03096, absmax 1.0, **0 NaNs** |
+| Also contains | full `optimizer` (AdamW) and `lr_scheduler` state, so a resume is exact |
+
+### Runs in W&B (`cataluna84/tayavision-tpu`)
+
+| Run id | Steps | Final loss | What it is |
+|---|---|---|---|
+| `e93fe1cd684c4c0f925bad9eeb38ddf1` | 2180 | **2.3665** | **The full epoch. This is the run that matters.** |
+| `2726cdffdb4d4e97b83265c2e1dcafab` | 19 | 5.7143 | Bounded smoke that gated the full run |
+| `a2d64c8e…`, `a0d4bea2…`, `9b0c8a97…` | <20 | — | Checkpoint-durability and resume self-tests |
+
+Eight further runs are in `failed`/`crashed` state; they are the debugging history in
+section 6 and can be deleted.
+
+---
+
+## 2. The result, measured
+
+Full epoch over LLaVA-Pretrain (558,128 caption pairs), SigLIP2-so400m frozen,
+`CohereLabs/tiny-aya-base` frozen, only the projector training.
+
+| Metric | Value |
+|---|---|
+| `train/loss` | 9.053 → **2.367** |
+| `perf/step_time` p50 | **1.508 s** per optimizer step |
+| p90 / max | 1.516 s / 2.014 s |
+| `perf/images_per_sec` | **169.2** |
+| `mem/used_gib` | 23.13 – **27.86** of 31.246 |
+| `xla/compile_cause_count` | **`[1]` — one single distinct value across all 2,180 steps** |
+| `train/max_image_tokens` | **196** every step (the SigLIP invariant) |
+| Step 1 / step 2 | 162.5 s / 56.5 s (compile); warm from step 4 |
+
+The flat compile counter is the most important line in that table. On XLA every distinct
+tensor shape is a new HLO compile, so with dynamic padding this number climbs forever.
+`[1]` across a whole epoch proves the fixed-sequence-length collate works.
+
+### Batch configuration, and why
+
+| Quantity | Value |
+|---|---|
+| Global batch | **128** |
+| Per host (of 4) | 32 |
+| Per chip (of 16) | **8** |
+| `grad_acc_steps` | **2** |
+| **Effective batch** | **256** |
+| Sequence length | **640**, fixed |
+| LR / warmup / schedule | **1e-3 / 0.03 / cosine — unchanged from the GPU baseline** |
+
+`B_eff = 256` matches the Modal GPU baseline exactly (there `batch_size=8 x grad_acc=32`).
+That is invariant #2 of `.claude/orchestration/playbook/perf-metrics-schema.md` and is what
+makes this loss curve comparable to the GPU one. **Do not change LR or warmup without
+changing `B_eff`, and vice versa.**
+
+**Global batch 256 does not fit.** It OOMs at step 2: *"Attempting to reserve 16.25G ...
+There are 15.69G free"*. 128x2 was chosen to halve activation memory while holding `B_eff`.
+
+### Sequence length 640 is measured, not guessed
+
+`tiny-aya-global` has a chat template with a ~370-token preamble, so a LLaVA-Pretrain
+sample is far longer than the caption suggests. Measured over 400 samples: **p99 = 599,
+max = 601**, image span ending at most at 569. 640 keeps 100% of samples intact.
+
+An earlier value of 256 silently truncated **every image token away**, which surfaced as
+`image_hidden_states is None` rather than as anything mentioning truncation.
+`collate_fn` now raises if `fixed_seq_len` would cut into image tokens.
+
+### Do not trust the analytical activation model
+
+It was wrong **four times in this project, always low**:
+
+1. Used `hidden_size` 2048 for the dominant term. Cohere2's FFN `intermediate_size` is
+   **11008** — 5.38x larger, and the MLP intermediates dominate.
+2. Assumed per-chip batch was `B_global / chips`. Nothing sharded the input.
+3. Corrected, still predicted 10.2 GiB against a measured 17.1.
+4. Predicted ~19.4 GiB for `B_global=128` by halving the 256 figure; actual peak **27.8**.
+   Halving the batch does not halve total memory — the static term and XLA's live fused
+   temporaries do not scale with batch.
+
+**Size batches by bisection and read `mem/used_gib`.** Treat any formula as an
+order-of-magnitude check only.
+
+---
+
+## 3. Resuming on GPU / Modal
+
+The Modal path is untouched and remains authoritative. The GPU code path is
+byte-equivalent to before this work: `uv run pytest tests/ -q` gives the same
+**121 passed / 8 errors** it did at the start (the 8 need gated HF repos), plus 31 new
+tests for the checkpointing added here.
+
+### Continue to Phase 2 (instruct) from the TPU-trained projector
+
+`config/training/instruct.yaml:22` already has the hook:
+
+```yaml
+alignment_checkpoint: "/data/model_ckpts/alignment_ckpts/4d93b48c-.../checkpoint_4361.pt"
+```
+
+Point it at this run's checkpoint instead — as a CLI override, per repo convention:
+
+```bash
+python pipeline/train_instruct.py training=instruct \
+  training.alignment_checkpoint=/path/to/checkpoint_4360.pt
+```
+
+The tensors are CPU bf16, so nothing about the TPU origin needs undoing.
+
+> Note the existing default there is a **UUID-bearing absolute path**, which is one of the
+> still-open Definition-of-Done items in `.claude/PLAN.md`.
+
+### Re-run Phase 1 on GPU for comparison
+
+```bash
+python pipeline/train_alignment.py training=alignment
+```
+
+`B_eff` is already 256 on that path (`batch_size=8 x grad_acc_steps=32`), so the loss curve
+should be directly comparable to the TPU run above. **Always pass `training=alignment`** —
+`config/config.yaml` defaults to `training: instruct`, which would silently run Phase 1
+with LR 2e-5 (50x too low) against the wrong dataset.
+
+---
+
+## 4. Resuming on TPU
+
+### Provision (see section 8 first — size matters)
+
+```bash
+TRC_PROFILE=v6e-16-ew4a \
+SAVE_CKPT_DIR=gs://tayavision-eu/checkpoints/<new-prefix> \
+bash scripts/tpu/launch_spot.sh
+
+TRC_PROFILE=v6e-16-ew4a bash scripts/tpu/ops.sh status   # wait for ACTIVE (~4-6 min)
+```
+
+### Stage the corpus (~3.5 min, 28 G, idempotent)
+
+```bash
+TRC_PROFILE=v6e-16-ew4a bash scripts/tpu/stage_data.sh
+TRC_PROFILE=v6e-16-ew4a bash scripts/tpu/ops.sh stage-logs
+```
+
+Runs detached in tmux `stage` on every worker and writes a `.staged` marker, so an
+interrupted invocation is resumable rather than corrupt.
+
+### Launch training (this is the exact command that produced the result)
+
+```bash
+TRC_PROFILE=v6e-16-ew4a \
+SAVE_CKPT_DIR=gs://tayavision-eu/checkpoints/<new-prefix> \
+TAYAVISION_ENTRYPOINT=pipeline/train_alignment.py \
+TAYAVISION_HYDRA_OVERRIDES='training=alignment training.batch_size=128 training.grad_acc_steps=2 training.fixed_seq_len=640 training.data_dir=/root/data/llava-pretrain training.num_workers=16' \
+bash scripts/tpu/deploy_tarball.sh
+```
+
+Add `training.max_steps=20` for a bounded smoke first. Expect **no step line for ~3.5 min**
+— that is XLA compiling.
+
+### Resume after a preemption
+
+```bash
+TAYAVISION_RESUME=auto ...   # resolves the newest mirrored checkpoint, refetches, resumes
+TAYAVISION_RESUME=<run-id>   # a specific run
+```
+
+`deploy_tarball.sh` defaults to `off`; `launch_qr.sh` and the boot path default to `auto`.
+That split is deliberate — see section 6.
+
+### Watch a run
+
+```bash
+TRC_PROFILE=v6e-16-ew4a bash scripts/tpu/ops.sh tail-logs
+```
+
+**Rank 0 is not necessarily gcloud worker 0.** In this run `process_index=0` lived on
+worker 1, and that is where tqdm and W&B write. `ops.sh tail-logs` follows worker 0. Grep
+for `[shard] process_index=` to find rank 0 before assuming a host is idle.
+
+---
+
+## 5. The code is NOT committed
+
+**This is the biggest risk in this handoff.** `HEAD` is still `25c9b79` and everything from
+this work lives in the working tree:
+
+- **19 modified tracked files**, +724 / -181 lines
+- **8 untracked paths**, including whole directories:
+  `src/backend/`, `scripts/tpu/`, `scripts/ci/`, `docs/tpu/`, `.claude/`,
+  `.github/workflows/tests.yml`, `tests/test_checkpoint_gcs.py`, `CLAUDE.md`, `.env.example`
+
+Nothing was committed or pushed because `CLAUDE.md` says not to without being asked, and
+upstream is the shared `Cohere-Labs-Community` repo. **Commit this to a branch before the
+working tree is lost.** Suggested:
+
+```bash
+git checkout -b tpu/backend-seam
+git add -A
+git commit -m "Add src/backend seam and TPU run control"
+```
+
+`.env` is gitignored and must stay that way. It is shipped to the VM inside the code
+tarball on purpose, because `CohereLabs/tiny-aya-*` are gated and there is no git clone in
+that flow.
+
+### What changed, by area
+
+| Path | Change |
+|---|---|
+| `src/backend/{base,gpu_backend,tpu_backend}.py` | New accelerator seam. `torch_xla` is confined to `tpu_backend.py`, enforced by `scripts/ci/check_backend_seam.sh` |
+| `pipeline/train_alignment.py` | Converted to the seam; collective-symmetry fixes; heartbeats; resume ordering |
+| `pipeline/data.py` | `fixed_seq_len` in `collate_fn`, plus a guard against truncating image tokens |
+| `pipeline/utils.py` | `gcs_checkpoint_root`, `mirror_checkpoint_to_gcs`, `fetch_checkpoint_from_gcs`, `resolve_resume_run_id` |
+| `scripts/tpu/` | 12 files: provisioning, deploy, staging, watchdog, ops |
+| `config/training/alignment.yaml` | `max_steps` and `fixed_seq_len` keys (Hydra struct mode rejects keys absent from the YAML) |
+| `tests/test_checkpoint_gcs.py` | 31 tests, all mocking `gcloud`; no bucket or network needed |
+| `.claude/orchestration/` | Run-control design; `playbook/baseline-v6e8-siglip-cohere2.md` holds the measured numbers |
+
+State at handoff: **`ruff check .` = 0**, backend-seam guard passes, **152 passed / 8
+errors** (the 8 are the pre-existing gated-repo tests).
+
+---
+
+## 6. Bugs found, and how to recognise them again
+
+Every one of these failed **silently**. None produced a traceback at the point of the bug.
+
+### 6.1 `if is_main:` around device work deadlocks SPMD
+
+**Signature:** all hosts idle in `futex_wait_queue`, host CPU ~1 jiffy/5 s, HBM resident,
+TPU duty cycle 0%, no traceback. Survived 2 h 39 min before being noticed, because "idle
+with memory allocated" is indistinguishable from "compiling" without a stack dump.
+
+**Cause:** under SPMD every host runs one program, so any device→host read (`.item()`,
+`.cpu()`, `state_dict()`) is effectively collective — it forces a graph execution all hosts
+must join. Rank 0 sat in `pn.std().item()` inside the W&B block while ranks 1-3 had already
+raced into the next step's forward.
+
+**Rule:** compute every scalar on **all** ranks; gate only `wandb.log`, `tqdm`, and disk
+writes. Checkpointing goes through `backend.save()`, which every rank calls.
+
+**Do not use `xm.save`** — it does `_maybe_convert_to_cpu(data, convert=should_write_data)`
+(`xla_model.py:1246`), i.e. it transfers **only on the writer**, the same asymmetry. Its
+docstring compensates by telling you to follow it with `xm.rendezvous`, but a barrier
+cannot repair a mismatch in the collective work itself.
+
+**Diagnosis that worked:** `py-spy dump --pid <main>` on every host, then compare where the
+four MainThreads sit. The divergence is obvious in one shot.
+
+### 6.2 Host-sharded input needs `ShardingSpec(minibatch=True)`
+
+**Signature:** identical to 6.1 — silent stall, no error.
+
+**Cause:** with each host loading a disjoint 1/N shard but `minibatch=False`, every host
+asserts that *its* 64 rows are the global tensor to split across all 16 chips. Nothing
+raises, because 64 divides 16 and every shape check passes.
+
+With `minibatch=True` torch_xla instead requires the per-host batch to divide by the
+**local** device count (`xla_model.py:1279`). The mesh stays **global** —
+`ShardingSpec.__post_init__` derives its type from `xr.global_runtime_device_count()`.
+
+**Confirmation it is working:** the logged batch shape becomes the global `(256, 640)`
+rather than the per-host `(64, 640)`.
+
+### 6.3 `MpDeviceLoader` does not shard at all
+
+`torch_xla/distributed/parallel_loader.py` contains no `process_index`, `process_count`, or
+any `xr.*` call. It wraps, prefetches, and applies a `ShardingSpec` **if you give it one**.
+Without `input_sharding`, every chip processes the whole per-host batch.
+
+### 6.4 `xr.world_size()` and `xr.global_ordinal()` lie under SPMD
+
+They return **1** and **0** on every host. Use `xr.process_count()` and
+`xr.process_index()`. Using the former makes host sharding a silent no-op.
+
+### 6.5 `drop_last=False` is fatal on TPU, not merely wasteful
+
+The sampler's tail-drop leaves 139,532 per host, but 139,532/32 leaves a short final batch.
+That is (a) a new shape, i.e. a recompile every epoch, and (b) not divisible by the local
+chip count, so `minibatch=True` **raises** — at the very end of an otherwise complete epoch.
+
+### 6.6 `torch.load(map_location=<xla device>)` raises
+
+```
+RuntimeError: don't know how to restore data location of
+torch.storage.UntypedStorage (tagged with xla:0)
+```
+
+The tag names the **target**, not the file. Load to host and let `load_state_dict` place it.
+
+### 6.7 Resumed step counter double-counted
+
+`step = step_offset + _i` is correct only on the GPU **subset** path, where the loader
+yields only the remainder so `_i` restarts at 0. On the TPU **skip** path the loader still
+yields the whole epoch, so `_i` is already absolute. Resuming from step 8 reported step 16,
+tripped `max_steps` immediately, and exited `Training complete` having done **no work**.
+
+### 6.8 Two env knobs read as wired and were not
+
+`SAVE_CKPT_DIR` reached only `scripts/tpu/*.sh` (deploy warnings, QR metadata, the
+`qr_watch.sh` durability gate); no Python read it, and `/models` is plain local disk, not a
+GCS mount. `TAYAVISION_RESUME` was only echoed in a launcher banner.
+
+Both are now live. **When auditing this repo's env knobs, grep for a *consumer*, not for
+the assignment.**
+
+`TAYAVISION_RESUME`'s default had to move out of `_lib.sh`: `auto` resumes whatever ran
+last, which is right on the boot/recycle path (QR metadata is replayed verbatim, so
+overrides cannot drift) and wrong on a human redeploy, where overrides change between
+invocations and resuming would load run A's optimizer state into run B's config.
+
+### 6.9 `ops.sh delete` could never delete a slice you had finished using
+
+It omitted `--force`, and the API rejects deleting an `ACTIVE` queued resource
+(`code 9`, must be one of `ACCEPTED / WAITING_FOR_RESOURCES / SUSPENDED / FAILED`). The
+un-forced form only ever worked on husks. Fixed.
+
+### 6.10 Environment pinning
+
+`torch 2.9.1+cpu` / `torchvision 0.24.1+cpu` / `torch_xla 2.9.0` / `libtpu 0.0.21`, on
+**Python 3.12 exactly** — floored by `pyproject.toml`, ceilinged by libtpu's cp312 wheels.
+A torch/torchvision ABI mismatch surfaces misleadingly as
+`Could not import module 'AutoProcessor'`; the real error is `torchvision::nms does not
+exist`. `startup_script.sh` asserts the ABI immediately after install.
+
+---
+
+## 7. Known gaps
+
+| Gap | Detail |
+|---|---|
+| **Nothing is committed** | Section 5. Highest priority. |
+| Only Phase 1 ran on TPU | `train_instruct.py` and `train_multilingual.py` are **not** converted to the seam. They are still DDP+CUDA and will not run on TPU. |
+| No eval of the TPU checkpoint | The projector trained and the loss fell, but no CVQA/benchmark number was produced from it. |
+| ~~`train_multilingual.py` wandb project~~ | **Fixed.** It hardcoded `project="tayavision-multilingual"`, so a TPU bring-up run would have written into a GPU *results* project. Now `os.environ.get("WANDB_PROJECT") or "tayavision-multilingual"`; `cfg` is not in scope in `main()`, so the env var is the override channel — which is what `scripts/tpu/train_launcher.sh` already sets from `.env`. The literal stays as fallback, so Modal is byte-for-byte unchanged. |
+| Generation disabled on TPU | `_prepare_cache_for_generation` forces a `DynamicCache` whose shape grows per token, so each token is a new HLO. In-training sample logging is off on TPU by design. |
+| MoonViT untested on TPU | It emits a *variable* token count per image, which is unbounded recompilation on XLA. PLAN P1 belongs on the Modal path. |
+| `NTFY_TOPIC` empty | `qr_watch.sh` self-heals silently; fill it before any unattended run. |
+| `index_put`/`nonzero` | `models/tiny_aya_vision.py:173` uses `nonzero` because `masked_scatter_backward` is broken under inductor on CUDA. `nonzero` is a dynamic-shape op XLA dislikes. It works, but it forces a host sync per forward. Belongs behind the seam. |
+| Analytical memory model | Wrong four times. Bisect, do not compute. |
+
+---
+
+## 8. TRC capacity — read this before planning a bigger run
+
+Five provisioning attempts across ~10 hours in `europe-west4-a`, zone clean before each:
+
+| Profile | Attempts | Outcome |
+|---|---|---|
+| `v6e-64-ew4a` | 3 | **all FAILED** |
+| `v6e-32-ew4a` | 2 | **all FAILED** |
+| `v6e-16-ew4a` | 3 | **all ACTIVE**, ~4-6 min |
+
+Every failure identical: `WAITING_FOR_RESOURCES → PROVISIONING → SUSPENDING → FAILED`,
+`{"code": 13, "message": "an internal error has occurred"}`.
+
+**Read `code 13` as "no capacity at this slice size", not as a bug.** The service reaches
+`PROVISIONING` — it accepts and begins allocating — then withdraws. Quota is *not* the
+constraint: `IN_USE_ADDRESSES` measured 16/64. A failed QR **terminates rather than staying
+queued**, so waiting is not a strategy; each attempt is a fresh ~5-minute attempt.
+
+**16 chips was the practical ceiling on this grant in this zone.**
+
+Untried alternatives, with their real costs:
+
+- **`v6e-64-ue1d`** (us-east1-d) — cross-region: every checkpoint write pays egress against
+  the EU bucket, and staging pulls across regions.
+- **`v5e-64-ew4b`** (europe-west4-b) — co-located, and podslice quota demonstrably exists
+  (`TPU_LITE_PODSLICE_V5` limit 16, usage 0). But v5e has **16 GiB HBM/chip vs v6e's
+  31.25**, and this run already needs 27.8 GiB at per-chip batch 8, so the batch config
+  needs reworking and re-measuring, not just relaunching.
+
+If you do get 64 chips: use **per-chip batch 4** so global stays 256 and `B_eff` stays 256
+with `grad_acc_steps=1`. Raising `B_eff` means re-tuning LR — and the trap is not the LR but
+**warmup**, which is a *fraction* of total steps, so a 4x larger `B_eff` yields 4x fewer
+warmup steps to reach a higher LR on a randomly-initialised projector. That is a plausible
+NaN that would look like a hardware bug.
+
+---
+
+## 9. Full provenance
+
+| | |
+|---|---|
+| Slice | `v6e-16`, `europe-west4-a`, runtime `v2-alpha-tpuv6e`, spot |
+| Topology | **4 hosts x 4 chips** — measured, not the 8 chips/host the public tables imply |
+| Chips visible to SPMD | 16 (`xr.global_runtime_device_count()`) |
+| Mesh | 1-D over 16 chips, `("data", "model")` = (16, 1) |
+| `TPU_STRATEGY` | `replicated` — model is 8.06 GiB of 31.25, FSDPv2 buys nothing and costs the reduce-scatter NaN hazard |
+| Bucket | `gs://tayavision-eu` (co-located) |
+| Model | SigLIP2-so400m-p14-384 frozen + `MultiModalProjector` (11.5 M trainable) + `CohereLabs/tiny-aya-base` (3.35 B, frozen) |
+| Params | 4.33 B total; 8.058 GiB resident per chip in bf16 |
+| Dataset | LLaVA-Pretrain, 558,128 samples, sharded 139,532 per host |
+| Boot | QR submit → ACTIVE ~4-6 min; deps ~2 min; redeploy → first step ~90 s + 3.5 min compile |
+
+Related documents:
+
+- `.claude/orchestration/playbook/baseline-v6e8-siglip-cohere2.md` — the protected baseline, all measured
+- `.claude/orchestration/SPEC.md` — run loop, and §9 on what does not work yet
+- `.claude/agents/tpu-diagnoser.md` — canonical log-signature → diagnosis table
+- `docs/tpu/tpu-capacity-log.md` — full provisioning history
+- `scripts/tpu/README.md` — every environment variable and its default
+- `CLAUDE.md` — project guide, including the `training=alignment` trap

--- a/docs/tpu_alignment_handoff_2026-07.md
+++ b/docs/tpu_alignment_handoff_2026-07.md
@@ -3,9 +3,9 @@
 **Written 2026-07-26, the last day of the TRC grant.** Everything below was measured on
 real hardware, not estimated. Where something is unverified it says so.
 
-The headline: **Phase 1 alignment completed a full epoch on a Cloud TPU v6e-16 and the
-trained projector is safe in GCS.** The `src/backend/` seam now lets the same
-`pipeline/train_alignment.py` run on either CUDA/DDP or torch_xla/SPMD.
+The headline: **Phase 1 alignment completed a full epoch on a Cloud TPU v6e-16.** The
+`src/backend/` seam now lets the same `pipeline/train_alignment.py` run on either CUDA/DDP
+or torch_xla/SPMD.
 
 ---
 
@@ -16,14 +16,17 @@ trained projector is safe in GCS.** The `src/backend/` seam now lets the same
 | **Result** | Full 1-epoch alignment, 2,180 optimizer steps, loss **9.053 → 2.367** |
 | **Hardware** | v6e-16 (4 hosts x 4 chips), `europe-west4-a`, spot |
 | **Wall clock** | **59 min 08 s** |
-| **Trained weights** | `gs://tayavision-eu/checkpoints/v6e16-align-01/e93fe1cd-684c-4c0f-925b-ad9eeb38ddf1/checkpoint_4360.pt` |
-| **Local copy** | `outputs/tpu-align-v6e16-2026-07-25/checkpoint_4360.pt` (67 MB, gitignored) |
+| **Trained weights** | `outputs/tpu-align-v6e16-2026-07-25/checkpoint_4360.pt` — **local only, and gitignored.** See section 9. |
 | **W&B** | https://wandb.ai/cataluna84/tayavision-tpu/runs/e93fe1cd684c4c0f925bad9eeb38ddf1 |
 | **Effective batch** | **256 — deliberately identical to the Modal GPU baseline** |
-| **Biggest caveat** | **None of the code is committed.** See section 5. |
+| **Code** | Branch `tpu`, PR #76, CI green |
+| **GCP** | **Fully decommissioned** — slice and `gs://tayavision-eu` both deleted |
 
 The checkpoint is **backend-portable**: all tensors are CPU-resident bf16, so it loads on
 CUDA with no conversion. Verified by loading it (section 1).
+
+> **The weights exist in exactly one place: `outputs/` on one machine.** That directory is
+> gitignored, so it is not on GitHub and not in any bucket. Back it up.
 
 ---
 
@@ -32,16 +35,19 @@ CUDA with no conversion. Verified by loading it (section 1).
 ### The trained projector
 
 ```
-gs://tayavision-eu/checkpoints/v6e16-align-01/e93fe1cd-684c-4c0f-925b-ad9eeb38ddf1/
+outputs/tpu-align-v6e16-2026-07-25/         <- gitignored, LOCAL ONLY
     checkpoint_1000.pt   checkpoint_2000.pt   checkpoint_3000.pt
     checkpoint_4000.pt   checkpoint_4360.pt   <- final, end of epoch
     config.json
 ```
 
 Filenames count **micro-steps**; 4360 micro-steps = 2,180 optimizer steps at
-`grad_acc_steps=2`. The bucket lives in GCP project `ml-pipelines-315702` and is **not**
-part of the TRC grant, so it outlives the grant — but it is also billable storage, so
-confirm it still exists before relying on it.
+`grad_acc_steps=2`.
+
+These were mirrored to `gs://tayavision-eu` during the run, pulled down at wrap-up, and
+**MD5-verified against their GCS objects before that bucket was deleted** — so they are
+confirmed faithful copies, not assumed ones. Hashes are in section 9. There is no cloud
+copy any more.
 
 Verified contents of `checkpoint_4360.pt`:
 
@@ -179,7 +185,12 @@ with LR 2e-5 (50x too low) against the wrong dataset.
 
 ### Provision (see section 8 first — size matters)
 
+`gs://tayavision-eu` was deleted at wrap-up, so recreate it before anything else.
+`setup_gcp.sh` is idempotent and creates the bucket if absent:
+
 ```bash
+bash scripts/tpu/setup_gcp.sh
+
 TRC_PROFILE=v6e-16-ew4a \
 SAVE_CKPT_DIR=gs://tayavision-eu/checkpoints/<new-prefix> \
 bash scripts/tpu/launch_spot.sh
@@ -232,25 +243,49 @@ for `[shard] process_index=` to find rank 0 before assuming a host is idle.
 
 ---
 
-## 5. The code is NOT committed
+## 5. Where the code is
 
-**This is the biggest risk in this handoff.** `HEAD` is still `25c9b79` and everything from
-this work lives in the working tree:
+**Branch `tpu`, PR #76, CI green.** 90 files, +8,845 / -181.
 
-- **19 modified tracked files**, +724 / -181 lines
-- **8 untracked paths**, including whole directories:
-  `src/backend/`, `scripts/tpu/`, `scripts/ci/`, `docs/tpu/`, `.claude/`,
-  `.github/workflows/tests.yml`, `tests/test_checkpoint_gcs.py`, `CLAUDE.md`, `.env.example`
+https://github.com/Cohere-Labs-Community/expedition-tayavision/pull/76
 
-Nothing was committed or pushed because `CLAUDE.md` says not to without being asked, and
-upstream is the shared `Cohere-Labs-Community` repo. **Commit this to a branch before the
-working tree is lost.** Suggested:
+Ten commits, ordered so each stands alone and the branch bisects:
 
-```bash
-git checkout -b tpu/backend-seam
-git add -A
-git commit -m "Add src/backend seam and TPU run control"
+| Commit | |
+|---|---|
+| `74b9422` | ruff/pytest config, 76 → 0 lint findings, CI workflow |
+| `d681c9c` | `CLAUDE.md` + the `.claude/` memory system |
+| `1694ba6` | **`src/backend/` seam** + `check_backend_seam.sh` |
+| `11daf17` | TPU run control (`scripts/tpu/`, `docs/tpu/`) |
+| `5581944` | durable `gs://` checkpointing + 31 tests |
+| `a0ee236` | **trainer conversion + the six silent XLA bugs** |
+| `5f9e1e1` | W&B project routing fix |
+| `fd9eff6` | this document |
+| `860831a` | decommission plan |
+| `268f210` | `requires_gpu` fix — the CI failure described below |
+
+The `.claude/` memory files (`PLAN.md`, `PROGRESS.md`, `memories.md`) are **gitignored as
+per-contributor state**, so they are not on the branch. That is deliberate — `PROGRESS.md`
+is an append-only machine log that would conflict on every merge — but it does mean this
+document is the durable record, not those.
+
+### The CI failure worth knowing about
+
+The workflow added in `74b9422` failed on its first run and caught a bug in that same
+commit. `requires_gpu` was written as
+
+```python
+requires_gpu = pytest.mark.requires_gpu(pytest.mark.skipif(...))   # WRONG
 ```
+
+which does **not** compose two marks — calling a `MarkDecorator` with a non-callable
+argument stores it as a *parameter of the mark*, so the skipif is never applied. Six GPU
+tests then ran on the CPU-only runner and errored with `Found no NVIDIA driver`.
+
+**The broken version is invisible on any machine with a GPU**, because the skip is never
+needed there. Only a CPU-only runner distinguishes them. Fixed in `268f210` with a function
+decorator; verified by reproducing the runner with `CUDA_VISIBLE_DEVICES=""`, which turns
+the exact CI command from `135 passed, 6 errors` into `135 passed, 6 skipped`.
 
 `.env` is gitignored and must stay that way. It is shipped to the VM inside the code
 tarball on purpose, because `CohereLabs/tiny-aya-*` are gated and there is no git clone in
@@ -382,7 +417,7 @@ exist`. `startup_script.sh` asserts the ABI immediately after install.
 
 | Gap | Detail |
 |---|---|
-| **Nothing is committed** | Section 5. Highest priority. |
+| **Weights exist in one place only** | `outputs/` is gitignored and the bucket is deleted, so the trained projector lives on a single machine with no backup. Highest priority. Section 9. |
 | Only Phase 1 ran on TPU | `train_instruct.py` and `train_multilingual.py` are **not** converted to the seam. They are still DDP+CUDA and will not run on TPU. |
 | No eval of the TPU checkpoint | The projector trained and the loss fell, but no CVQA/benchmark number was produced from it. |
 | ~~`train_multilingual.py` wandb project~~ | **Fixed.** It hardcoded `project="tayavision-multilingual"`, so a TPU bring-up run would have written into a GPU *results* project. Now `os.environ.get("WANDB_PROJECT") or "tayavision-multilingual"`; `cfg` is not in scope in `main()`, so the env var is the override channel — which is what `scripts/tpu/train_launcher.sh` already sets from `.env`. The literal stays as fallback, so Modal is byte-for-byte unchanged. |
@@ -431,82 +466,68 @@ NaN that would look like a hardware bug.
 
 ---
 
-## 9. Decommission plan
+## 9. Decommission — DONE
 
-The TPU slice is **already deleted** (2026-07-26): zero queued resources, zero nodes in
-`europe-west4-a`. TPU billing has stopped. What remains is `gs://tayavision-eu`, ~963 MiB.
+**Fully torn down 2026-07-26. Nothing of this project remains in GCP.**
 
-### Step 1 — delete `code/` and rotate the tokens (do this first)
+| Resource | State |
+|---|---|
+| v6e-16 slice + queued resource | **deleted** — `europe-west4-a` verified clean, 0 QRs, 0 nodes |
+| `gs://tayavision-eu` | **deleted**, bucket and all 963 MiB of contents |
+| Trained weights | **preserved locally**, all five checkpoints, each MD5-verified against the remote before deletion |
 
-```bash
-gcloud storage rm -r gs://tayavision-eu/code
-```
+### Where the weights are now
 
-**45 tarballs, 566 MiB, and every one contains a live `.env`.** Verified, not assumed:
+`outputs/tpu-align-v6e16-2026-07-25/` — 331 MB, **gitignored, so this directory is the only
+copy that exists anywhere.** Back it up if it matters to you.
 
-```
+| File | MD5 (base64) |
+|---|---|
+| `checkpoint_1000.pt` | `mtB7CLQSRYeJlYqGwUCurQ==` |
+| `checkpoint_2000.pt` | `l+/JVOTVksEkCBB3Ikm5vQ==` |
+| `checkpoint_3000.pt` | `U6YFJxb22teEwhvTuzhBng==` |
+| `checkpoint_4000.pt` | `EqvkeKHW/o1AJSWhLKI+vw==` |
+| **`checkpoint_4360.pt`** | `Uw0Cd5zogH3iBH8Ew9gcMw==` — **the final, end-of-epoch projector** |
+| `config.json` | — |
+
+Each was byte-compared to its GCS object before the bucket was removed, so these are
+faithful copies rather than assumed ones.
+
+### Rotate the tokens
+
+`gs://tayavision-eu/code/` held 45 deploy tarballs, each containing a live `.env`. Verified
+at the time, not assumed:
+
+```console
 $ gcloud storage cat gs://tayavision-eu/code/latest.tar.gz | tar tzf - | grep '\.env$'
 ./.env
 ```
 
-That was deliberate and correct while the slice existed — `CohereLabs/tiny-aya-*` are gated,
-there is no git clone in the TPU flow, so the tarball was the only channel credentials had
-(see `.env.example` and `scripts/tpu/_lib.sh:make_code_tarball`). With the slice gone it is
-only exposure: 45 copies of a live `HF_TOKEN` and `WANDB_API_KEY` at rest.
+They are gone now, but **deleting objects does not undo a read that may already have
+happened**. Rotate `HF_TOKEN` and `WANDB_API_KEY`.
 
-The bucket reports **no explicit `publicAccessPrevention` and no uniform bucket-level
-access** — that does not mean it is public, but it does mean nothing is enforcing that it
-stays private.
+If the tarball-ships-`.env` mechanism is used again, give it a lifecycle rule or fetch
+secrets at boot instead of leaving snapshots at rest.
 
-**Rotate `HF_TOKEN` and `WANDB_API_KEY` regardless of whether you delete the bucket.**
-Deleting the objects does not un-exfiltrate anything that may already have been read, and
-rotation is cheap.
+### Before the next TPU run
 
-The code itself is not lost: it is on the `tpu` branch. The tarballs are snapshots of it.
-
-### Step 2 — decide about `checkpoints/` (396.5 MiB)
+The bucket no longer exists, and `scripts/tpu/_lib.sh:20` still defaults `BUCKET` to
+`gs://tayavision-eu`. Recreate it first — `setup_gcp.sh` is idempotent and creates it if
+absent:
 
 ```bash
-# Inspect before removing anything
-gcloud storage ls -r 'gs://tayavision-eu/checkpoints/**'
+bash scripts/tpu/setup_gcp.sh          # recreates gs://tayavision-eu in europe-west4
+TRC_PROFILE=v6e-16-ew4a bash scripts/tpu/launch_spot.sh
 ```
 
-`v6e16-align-01/e93fe1cd-.../checkpoint_4360.pt` is **the trained projector** — the single
-scientific output of this work. A local copy exists at
-`outputs/tpu-align-v6e16-2026-07-25/checkpoint_4360.pt` (67 MB, gitignored, verified
-loadable), so deleting the bucket copy is survivable but leaves exactly one copy on one
-laptop.
+Everything else in section 4 then applies unchanged.
 
-Recommended: **keep** `v6e16-align-01/`, or move it somewhere long-lived (a HF repo, or
-`gs://` in a project you are keeping) before deleting. The seven sibling run-id directories
-under that prefix hold only `config.json` from failed attempts and can go:
+### Not ours — left alone
 
-```bash
-# Keeps the one directory that matters, removes the debris
-gcloud storage ls gs://tayavision-eu/checkpoints/v6e16-align-01/ \
-  | grep -v e93fe1cd-684c-4c0f-925b-ad9eeb38ddf1 \
-  | xargs -r -I{} gcloud storage rm -r {}
-```
-
-### Step 3 — the bucket itself
-
-Only once steps 1 and 2 are settled:
-
-```bash
-gcloud storage rm -r gs://tayavision-eu     # contents
-gcloud storage buckets delete gs://tayavision-eu
-```
-
-The bucket is in project `ml-pipelines-315702` and is **not** part of the TRC grant, so it
-does not disappear on its own — it will keep costing storage until deleted. At ~963 MiB
-that is cents per month, so there is no urgency on cost grounds; the urgency is entirely
-step 1.
-
-### What is already done
-
-- TPU slice and queued resource deleted; zone verified clean.
-- Trained weights copied locally and verified loadable.
-- All code committed to branch `tpu` and pushed; PR #76 open.
+`gs://tinyaya-stage2-eu` (**391 GiB**, `europe-west4`) belongs to the sibling project
+`tinyaya-stage2-scale`, which shares this GCP project and the same TRC grant. It was **not**
+touched. At europe-west4 Standard pricing that is roughly **$8/month**, so it is worth
+confirming it is still wanted — but that is a decision for that project, not this one.
 
 ## 10. Full provenance
 

--- a/evaluation/ablation_cvqa.py
+++ b/evaluation/ablation_cvqa.py
@@ -125,7 +125,7 @@ def print_table(models: list[ModelScores], min_samples: int) -> list[dict]:
     overall = {}
     for model in models:
         total = sum(model.counts.values())
-        overall[model.label] = sum(model.accuracies[l] * model.counts[l] for l in model.accuracies) / total
+        overall[model.label] = sum(model.accuracies[lang] * model.counts[lang] for lang in model.accuracies) / total
     score_cells = "".join(f"  {overall[model.label] * 100:>17.1f}%" for model in models)
     baseline_score = overall[baseline]
     delta_cells = "".join(

--- a/evaluation/run_eval.py
+++ b/evaluation/run_eval.py
@@ -98,7 +98,7 @@ def main():
     logger.info(f"Model: {args.model_name}")
     if args.model_subfolder:
         logger.info(f"Model subfolder: {args.model_subfolder}")
-    logger.info(f"=========================================")
+    logger.info("=========================================")
 
     # Register TinyAyaVision with HuggingFace Auto classes so lm-eval can
     # load it via AutoModelForCausalLM.from_pretrained / AutoConfig.
@@ -218,7 +218,6 @@ def main():
                     if isinstance(v, (int, float)) and k != "doc_id":
                         sample_metrics.setdefault(k, []).append(v)
 
-            n_so_far = n_done + (chunk_idx + 1 - n_done // args.chunk_size) * args.chunk_size
             running_metrics = {k: sum(vs) / len(vs) for k, vs in sample_metrics.items()}
             elapsed = time.monotonic() - eval_start_time
             logger.info(

--- a/evaluation/tiny_aya_vision_lm_eval.py
+++ b/evaluation/tiny_aya_vision_lm_eval.py
@@ -16,7 +16,7 @@ import transformers
 from lm_eval.api.registry import register_model
 from lm_eval.models.hf_vlms import HFMultimodalLM
 
-import models  # registers TinyAyaVision with HF Auto classes
+import models  # noqa: F401  (imported for its side effect: registers TinyAyaVision with HF Auto classes)
 from config.model_config import TinyAyaVisionConfig
 from src.processing import TinyAyaVisionProcessor
 from evaluation.tasks.maxm.utils import vqa_score

--- a/pipeline/data.py
+++ b/pipeline/data.py
@@ -1,4 +1,3 @@
-import json
 import os
 import torch
 
@@ -283,17 +282,68 @@ class InstructDataset(torch.utils.data.Dataset):
 def collate_fn(
     batch,
     pad_token_id: int,
+    fixed_seq_len: int | None = None,
+    image_token_id: int | None = None,
 ):
-    input_ids = torch.nn.utils.rnn.pad_sequence(
-        [item["input_ids"] for item in batch],
-        batch_first=True,
-        padding_value=pad_token_id,
-    )
-    attention_mask = torch.nn.utils.rnn.pad_sequence(
-        [item["attention_mask"] for item in batch],
-        batch_first=True,
-        padding_value=0,
-    )
+    """Collate a batch, optionally to a FIXED sequence length.
+
+    `fixed_seq_len=None` (the default) pads to the longest item in the batch --
+    unchanged behaviour, and what the CUDA/Modal path uses.
+
+    Set it on XLA. `pad_sequence` produces a different sequence length for
+    almost every batch, and on XLA **every distinct shape is a new HLO compile**,
+    so compilation never converges and `xla/compile_cause_count` climbs forever.
+    Padding to one length makes the graph shape-stable. It also pins activation
+    memory, which is linear in sequence length.
+
+    Sequences longer than `fixed_seq_len` ARE TRUNCATED, so the value must cover
+    the real distribution. Measured on LLaVA-Pretrain with the tiny-aya-global
+    tokenizer (400 random samples, 2026-07-25):
+
+        seq len          min 571   p50 585   p99 599   max 601
+        image span ends            max 569
+
+    The instruction-tuned tokenizer HAS a chat template, whose system preamble
+    pushes the 196 image tokens out to positions ~372-569 -- nowhere near the
+    start. A value of 256 (which looks generous next to "196 image tokens plus a
+    short caption") silently truncates away **every image token**, and the model
+    then trains on text alone while reporting a perfectly plausible loss.
+    640 keeps 100% of image tokens and 100% of the text.
+
+    Pass `image_token_id` to make that failure impossible: truncation that drops
+    image tokens then raises instead of training on nothing.
+    """
+
+    def _pad(seqs, value):
+        out = torch.nn.utils.rnn.pad_sequence(
+            seqs, batch_first=True, padding_value=value
+        )
+        if fixed_seq_len is None:
+            return out
+        cur = out.size(1)
+        if cur > fixed_seq_len:
+            return out[:, :fixed_seq_len]
+        if cur < fixed_seq_len:
+            pad = out.new_full((out.size(0), fixed_seq_len - cur), value)
+            return torch.cat([out, pad], dim=1)
+        return out
+
+    raw_ids = [item["input_ids"] for item in batch]
+    input_ids = _pad(raw_ids, pad_token_id)
+    attention_mask = _pad([item["attention_mask"] for item in batch], 0)
+
+    if fixed_seq_len is not None and image_token_id is not None:
+        before = sum(int((s == image_token_id).sum()) for s in raw_ids)
+        after = int((input_ids == image_token_id).sum())
+        if before and after < before:
+            longest = max(len(s) for s in raw_ids)
+            raise ValueError(
+                f"fixed_seq_len={fixed_seq_len} truncated away image tokens: "
+                f"{before} present before, {after} after (longest sequence in this "
+                f"batch is {longest}). The model would train on text alone and "
+                f"still report a plausible loss. Raise fixed_seq_len above the "
+                f"position where the image span ends."
+            )
     # Collate pixel_values only for items that have images (skip text-only).
     image_items = [item for item in batch if item["pixel_values"] is not None]
     if image_items:
@@ -304,11 +354,7 @@ def collate_fn(
     else:
         pixel_values = None
 
-    labels = torch.nn.utils.rnn.pad_sequence(
-        [item["labels"] for item in batch],
-        batch_first=True,
-        padding_value=-100,
-    )
+    labels = _pad([item["labels"] for item in batch], -100)
 
     result = {
         "input_ids": input_ids,

--- a/pipeline/multilingual_data.py
+++ b/pipeline/multilingual_data.py
@@ -17,7 +17,6 @@ Dataset schemas (verified from HF / GitHub):
 """
 
 import json
-import os
 from collections import defaultdict
 from pathlib import Path
 
@@ -77,7 +76,7 @@ def compute_temperature_weights(
     T→∞: uniform across all languages
     """
     langs = list(lang_counts.keys())
-    counts = np.array([lang_counts[l] for l in langs], dtype=np.float64)
+    counts = np.array([lang_counts[lang] for lang in langs], dtype=np.float64)
 
     # Avoid division by zero for empty languages
     counts = np.maximum(counts, 1.0)
@@ -108,10 +107,11 @@ def compute_sampling_indices(
     data. This enables more uniform distribution across languages.
     When False, each language is capped at its available count.
     """
-    rng = np.random.RandomState(seed)
-
+    # No RNG here: this function only computes per-language target counts and is
+    # fully deterministic. `seed` is accepted for signature stability and is
+    # unused -- the actual sampling (with replacement) happens downstream.
     en_count = lang_counts.get("en", 0)
-    non_en_counts = {l: c for l, c in lang_counts.items() if l != "en"}
+    non_en_counts = {lang: c for lang, c in lang_counts.items() if lang != "en"}
 
     # Allocate English budget
     en_budget = int(total_samples * english_ratio)
@@ -122,16 +122,16 @@ def compute_sampling_indices(
     if non_en_counts:
         non_en_weights = compute_temperature_weights(non_en_counts, temperature)
         target_per_lang = {
-            l: int(non_en_budget * w) for l, w in non_en_weights.items()
+            lang: int(non_en_budget * w) for lang, w in non_en_weights.items()
         }
-        for l in target_per_lang:
+        for lang in target_per_lang:
             if allow_upsampling:
                 # Allow upsampling up to max_upsample_factor × available data
-                cap = int(non_en_counts[l] * max_upsample_factor)
-                target_per_lang[l] = min(target_per_lang[l], cap)
+                cap = int(non_en_counts[lang] * max_upsample_factor)
+                target_per_lang[lang] = min(target_per_lang[lang], cap)
             else:
                 # Hard cap at available data
-                target_per_lang[l] = min(target_per_lang[l], non_en_counts[l])
+                target_per_lang[lang] = min(target_per_lang[lang], non_en_counts[lang])
     else:
         target_per_lang = {}
 
@@ -252,7 +252,7 @@ class PangeaInsSource(DatasetSource):
 
         # Fast path: load from cached Parquet
         if parquet_path.exists():
-            print(f"    Loading PangeaIns from cached Parquet...")
+            print("    Loading PangeaIns from cached Parquet...")
             ds = HFDataset.from_parquet(str(parquet_path))
             if max_samples and len(ds) > max_samples:
                 ds = ds.shuffle(seed=42).select(range(max_samples))
@@ -266,7 +266,7 @@ class PangeaInsSource(DatasetSource):
                 records = orjson.loads(f.read())
             print(f"    Parsed {len(records):,} records with orjson")
         except ImportError:
-            print(f"    orjson not available, falling back to stdlib json (slower)...")
+            print("    orjson not available, falling back to stdlib json (slower)...")
             with open(json_path, "r") as f:
                 records = json.load(f)
             print(f"    Parsed {len(records):,} records with json")
@@ -276,7 +276,7 @@ class PangeaInsSource(DatasetSource):
             if "conversations" in r and isinstance(r["conversations"], list):
                 r["conversations"] = json.dumps(r["conversations"])
 
-        print(f"    Converting to Arrow dataset...")
+        print("    Converting to Arrow dataset...")
         df = pd.DataFrame(records)
         del records  # free ~12 GB
         # Coerce mixed-type columns to strings to avoid ArrowTypeError
@@ -326,7 +326,7 @@ class PaloSource(DatasetSource):
         parquet_path = Path(local_dir) / "palo_multilingual_dataset.parquet"
 
         if not json_path.exists() and not parquet_path.exists():
-            print(f"    Downloading palo_multilingual_dataset.json (~13GB)...")
+            print("    Downloading palo_multilingual_dataset.json (~13GB)...")
             hf_hub_download(
                 repo_id=self.hf_dataset_id,
                 filename="palo_multilingual_dataset.json",
@@ -337,7 +337,7 @@ class PaloSource(DatasetSource):
 
         # Fast path: load from cached Parquet
         if parquet_path.exists():
-            print(f"    Loading PALO from cached Parquet...")
+            print("    Loading PALO from cached Parquet...")
             ds = HFDataset.from_parquet(str(parquet_path))
             if max_samples and len(ds) > max_samples:
                 ds = ds.shuffle(seed=42).select(range(max_samples))
@@ -351,7 +351,7 @@ class PaloSource(DatasetSource):
                 records = orjson.loads(f.read())
             print(f"    Parsed {len(records):,} records with orjson")
         except ImportError:
-            print(f"    orjson not available, falling back to stdlib json (slower)...")
+            print("    orjson not available, falling back to stdlib json (slower)...")
             with open(json_path, "r") as f:
                 records = json.load(f)
             print(f"    Parsed {len(records):,} records with json")
@@ -360,7 +360,7 @@ class PaloSource(DatasetSource):
             if "conversations" in r and isinstance(r["conversations"], list):
                 r["conversations"] = json.dumps(r["conversations"])
 
-        print(f"    Converting to Arrow dataset...")
+        print("    Converting to Arrow dataset...")
         df = pd.DataFrame(records)
         del records
         for col in df.columns:
@@ -407,7 +407,7 @@ class LLaVAInstructSource(DatasetSource):
         parquet_path = Path(local_dir) / "llava_instruct_150k.parquet"
 
         if not json_path.exists() and not parquet_path.exists():
-            print(f"    Downloading llava_instruct_150k.json...")
+            print("    Downloading llava_instruct_150k.json...")
             hf_hub_download(
                 repo_id=self.hf_dataset_id,
                 filename="llava_instruct_150k.json",
@@ -418,14 +418,14 @@ class LLaVAInstructSource(DatasetSource):
 
         # Fast path: load from cached Parquet
         if parquet_path.exists():
-            print(f"    Loading LLaVA-Instruct from cached Parquet...")
+            print("    Loading LLaVA-Instruct from cached Parquet...")
             ds = HFDataset.from_parquet(str(parquet_path))
             if max_samples and len(ds) > max_samples:
                 ds = ds.shuffle(seed=42).select(range(max_samples))
             return ds
 
         # First load: parse JSON → Arrow → Parquet cache
-        print(f"    Parsing llava_instruct_150k.json...")
+        print("    Parsing llava_instruct_150k.json...")
         try:
             import orjson
             with open(json_path, "rb") as f:
@@ -440,7 +440,7 @@ class LLaVAInstructSource(DatasetSource):
             if "conversations" in r and isinstance(r["conversations"], list):
                 r["conversations"] = json.dumps(r["conversations"])
 
-        print(f"    Converting to Arrow dataset...")
+        print("    Converting to Arrow dataset...")
         df = pd.DataFrame(records)
         del records
         for col in df.columns:
@@ -451,7 +451,7 @@ class LLaVAInstructSource(DatasetSource):
 
         print(f"    Caching as Parquet at {parquet_path}...")
         ds.to_parquet(str(parquet_path))
-        print(f"    Parquet cache saved")
+        print("    Parquet cache saved")
 
         if max_samples and len(ds) > max_samples:
             ds = ds.shuffle(seed=42).select(range(max_samples))
@@ -989,7 +989,7 @@ class BloomCaptioningSource(DatasetSource):
                               cache_dir=cache_dir, trust_remote_code=True)
         except Exception as e:
             print(f"    bloom-captioning: could not load (gated?): {e}")
-            print(f"    Falling back to empty dataset")
+            print("    Falling back to empty dataset")
             return HFDataset.from_list([])
 
         if max_samples and len(ds) > max_samples:
@@ -1144,7 +1144,7 @@ class MultilingualInstructDataset(torch.utils.data.Dataset):
                 self._lang_examples[lang].append((src, example))
 
         # Report language distribution before mixing
-        lang_counts = {l: len(exs) for l, exs in self._lang_examples.items()}
+        lang_counts = {lg: len(exs) for lg, exs in self._lang_examples.items()}
         total_available = sum(lang_counts.values())
         print(f"\nAvailable data: {total_available} examples across {len(lang_counts)} languages")
         for lang in sorted(lang_counts, key=lang_counts.get, reverse=True)[:20]:

--- a/pipeline/train_alignment.py
+++ b/pipeline/train_alignment.py
@@ -1,4 +1,7 @@
-"""Alignment pre-training pipeline for Tiny Aya Vision (DDP).
+"""Alignment pre-training pipeline for Tiny Aya Vision.
+
+Accelerator behaviour (device, autocast, distribution, sampling, stepping) lives
+behind `src/backend/`. Selected by TAYAVISION_TPU=1; defaults to DDP + CUDA.
 
 Phase 1 training — trains only the multi-modal projector (connector) to align
 vision encoder features with the LLM embedding space, using LLaVA-Pretrain
@@ -28,9 +31,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import numpy as np
 import torch
-import torch.distributed as dist
 from PIL import Image
-from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data.distributed import DistributedSampler
 import wandb
 from tqdm import tqdm
@@ -40,14 +41,14 @@ from config.model_config import TinyAyaVisionConfig
 from models.tiny_aya_vision import TinyAyaVisionForConditionalGeneration
 from pipeline.data import AlignmentDataset, collate_fn
 from pipeline.utils import (
-    is_torchrun,
-    setup_ddp,
-    cleanup_ddp,
     _unwrap_model,
     save_checkpoint,
+    fetch_checkpoint_from_gcs,
     find_latest_checkpoint,
+    resolve_resume_run_id,
     build_lr_scheduler,
 )
+from src.backend import create_backend
 from src.processing import TinyAyaVisionProcessor
 
 
@@ -58,6 +59,7 @@ def generate_samples(
     processor: TinyAyaVisionProcessor,
     compute_dtype: torch.dtype,
     device: torch.device,
+    backend,
     max_new_tokens: int = 256,
     num_samples: int = 2,
 ) -> list[dict[str, str]]:
@@ -84,7 +86,7 @@ def generate_samples(
         prompt_mask = batch["attention_mask"][i, :prompt_len].unsqueeze(0).to(device)
         pixel_values = batch["pixel_values"][i].unsqueeze(0).to(device)
 
-        with torch.autocast("cuda", dtype=compute_dtype):
+        with backend.autocast(compute_dtype):
             inputs_embeds = raw.get_input_embeddings()(prompt_ids)
             image_features = raw.get_image_features(pixel_values)
             inputs_embeds = raw._merge_image_features(
@@ -135,14 +137,17 @@ def train(
     image_token_id: int,
     processor: TinyAyaVisionProcessor | None = None,
     step_offset: int = 0,
+    backend=None,
+    batches_to_skip: int = 0,
 ):
     model.train()
     accumulated_loss = 0.0
     accumulated_ce_loss = 0.0
     accumulated_align_reg_loss = 0.0
     max_image_tokens_in_window = 0
-    use_ddp = dist.is_initialized()
-    is_main = (not use_ddp) or dist.get_rank() == 0
+    if backend is None:  # direct callers / tests get the GPU path unchanged
+        backend = create_backend("gpu")
+    is_main = backend.is_main
 
     # Accumulate generation samples across save steps
     generation_rows = []
@@ -156,6 +161,12 @@ def train(
             norm_cache["projector_token"] = norms
     hook_handle = raw.multi_modal_projector.register_forward_hook(_projector_hook)
 
+    # Wall time per OPTIMIZER step (i.e. across the whole grad-acc window), which
+    # is the unit `playbook/perf-metrics-schema.md` compares across slices.
+    import time as _time
+    _last_step_t = _time.monotonic()
+    _step_is_first = True  # the image-merge guard only needs to fire once
+
     for epoch in range(training_config.num_epochs):
         if sampler is not None:
             sampler.set_epoch(epoch)
@@ -165,7 +176,46 @@ def train(
             dynamic_ncols=True,
             disable=not is_main,
         )
-        for step, batch in enumerate(pbar, start=step_offset):
+        # Heartbeats, printed on EVERY host (not just main) and unconditionally.
+        # Between them sits the loader; after them sits XLA tracing + compile.
+        # Without these two lines a stall in either place looks identical from
+        # the log: a v6e-16 run once sat silent for 2h39m between the `[shard]`
+        # line and step 1, and the log could not say which half was stuck.
+        print(f"[loop] rank={backend.rank} epoch={epoch} awaiting first batch",
+              flush=True)
+        _first_batch = True
+        for _i, batch in enumerate(pbar):
+            if _first_batch:
+                _first_batch = False
+                print(f"[loop] rank={backend.rank} first batch received "
+                      f"shape={tuple(batch['input_ids'].shape)}; "
+                      "tracing + compiling step 1", flush=True)
+            # Skip AFTER the sampler has sharded, so a resume cannot move shard
+            # boundaries. Cheap: the collate never runs for skipped batches.
+            if _i < batches_to_skip:
+                continue
+            # `_i` indexes whatever the loader yields, and the two resume
+            # strategies yield different things:
+            #
+            #   skip   (TPU)  -- the loader still yields the WHOLE epoch, so `_i`
+            #                    is already the absolute step. Adding the offset
+            #                    double-counts it.
+            #   subset (GPU)  -- the loader yields only the remainder, so `_i`
+            #                    restarts at 0 and the offset is required.
+            #
+            # Getting this wrong is quiet: data is still correct (the skip
+            # itself is right), but the step counter, the LR schedule position,
+            # and the `max_steps` test all jump ahead by `resume_step`. Measured
+            # on a v6e-16 resume from step 8: the first resumed batch reported
+            # step 16 and `max_steps` tripped immediately, so the run did zero
+            # further work and still exited "Training complete".
+            step = _i if batches_to_skip else step_offset + _i
+            if (training_config.max_steps is not None
+                    and (step + 1) // training_config.grad_acc_steps
+                    >= training_config.max_steps):
+                if is_main:
+                    print(f"max_steps={training_config.max_steps} reached", flush=True)
+                break
             input_ids, attention_mask, pixel_values, labels = (
                 batch["input_ids"].to(device, non_blocking=True),
                 batch["attention_mask"].to(device, non_blocking=True),
@@ -181,7 +231,7 @@ def train(
                 (input_ids == image_token_id).sum(dim=1).max().item(),
             )
 
-            with torch.autocast("cuda", dtype=compute_dtype):
+            with backend.autocast(compute_dtype):
                 outputs = model(
                     input_ids=input_ids,
                     attention_mask=attention_mask,
@@ -191,15 +241,46 @@ def train(
                     use_cache=False,
                 )
                 ce_loss = outputs.loss / training_config.grad_acc_steps
+                image_hidden_states = outputs.image_hidden_states  # (B,V,D) or (tokens,D)
 
-                token_embeddings = raw.language_model.get_input_embeddings().weight  # (vocab size, D)
-                image_hidden_states = outputs.image_hidden_states  # (B, V, D) or (total_tokens, D)
+                # image_hidden_states is None exactly when the model did NOT merge
+                # any image features -- i.e. `pixel_values is None` or the model
+                # found none of its image_token_id in input_ids
+                # (models/tiny_aya_vision.py:196). That means the batch trained as
+                # TEXT ONLY. For an alignment run whose entire purpose is aligning
+                # the projector, that is not a degraded run, it is a meaningless
+                # one, so fail loudly on the first batch rather than produce a
+                # plausible-looking loss curve.
+                if image_hidden_states is None and _step_is_first:
+                    n_img_tok = int((input_ids == image_token_id).sum())
+                    raise RuntimeError(
+                        "model returned image_hidden_states=None: no image features "
+                        "were merged, so this batch trained on text alone.\n"
+                        f"  pixel_values is None      : {pixel_values is None}\n"
+                        f"  train() image_token_id    : {image_token_id}\n"
+                        f"  model.image_token_id      : {getattr(raw, 'image_token_id', '<unset>')}\n"
+                        f"  image tokens in input_ids : {n_img_tok}\n"
+                        f"  input_ids shape           : {tuple(input_ids.shape)}\n"
+                        "If the two ids differ, setup_tokenizer() did not take effect. "
+                        "If the count is 0, the collate truncated them away."
+                    )
+                _step_is_first = False
 
-                # Flatten to 2-D for both SigLIP (B, V, D) and MoonViT (total_tokens, D)
-                ihs = image_hidden_states.reshape(-1, image_hidden_states.shape[-1])
-                align_reg_loss = (token_embeddings.mean(dim=0) - ihs.mean(dim=0)).square().sum() \
-                                + (token_embeddings.std(dim=0) - ihs.std(dim=0)).square().sum()
-                align_reg_loss /= training_config.grad_acc_steps
+                # Only compute the alignment regulariser when it is actually
+                # weighted. It defaults to embed_align_reg=0.0, so this was pure
+                # wasted compute on every step -- two full-vocab mean/std
+                # reductions over a 262144 x 2048 embedding matrix.
+                if training_config.embed_align_reg:
+                    token_embeddings = raw.language_model.get_input_embeddings().weight
+                    # Flatten to 2-D for SigLIP (B,V,D) and MoonViT (tokens,D) alike
+                    ihs = image_hidden_states.reshape(-1, image_hidden_states.shape[-1])
+                    align_reg_loss = (
+                        (token_embeddings.mean(dim=0) - ihs.mean(dim=0)).square().sum()
+                        + (token_embeddings.std(dim=0) - ihs.std(dim=0)).square().sum()
+                    ) / training_config.grad_acc_steps
+                else:
+                    align_reg_loss = torch.zeros((), device=ce_loss.device,
+                                                 dtype=ce_loss.dtype)
 
             loss = ce_loss + training_config.embed_align_reg * align_reg_loss
             loss.backward()
@@ -212,40 +293,92 @@ def train(
                 grad_norm = torch.nn.utils.clip_grad_norm_(
                     raw.multi_modal_projector.parameters(), training_config.max_grad_norm
                 )
-                optimizer.step()
+                backend.optimizer_step(optimizer)
                 lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 
                 opt_step = (step + 1) // training_config.grad_acc_steps
 
+                # --- device work: EVERY host, identically --------------------
+                #
+                # Under SPMD every host runs the same program, and any read of a
+                # device tensor back to host (.item(), .cpu(), state_dict()) is
+                # effectively a collective: it forces a graph execution that all
+                # hosts must join. Putting one behind `if is_main` desynchronises
+                # the mesh and deadlocks it -- silently, with no traceback.
+                #
+                # Measured 2026-07-25 on the v6e-16, tag deploy-20260725-122244:
+                # rank 0 sat forever in `pn.std().item()` while ranks 1-3 had
+                # already raced into step 2's forward at tiny_aya_vision.py:162.
+                # Each group waited on a collective the other would never issue;
+                # all four hosts idle, HBM resident, duty cycle 0%.
+                #
+                # So: compute every scalar here, on all ranks. Only the pure
+                # host-side side effects below (wandb, tqdm, disk) are gated.
+                _now = _time.monotonic()
+                _step_time = _now - _last_step_t
+                _last_step_t = _now
+                _grad_norm = grad_norm.item()
+
+                log_dict = {
+                    "train/loss": accumulated_loss,
+                    "train/ce_loss": accumulated_ce_loss,
+                    "train/align_reg_loss": accumulated_align_reg_loss,
+                    "train/grad_norm": _grad_norm,
+                    "train/lr": lr_scheduler.get_last_lr()[0],
+                    "train/max_image_tokens": max_image_tokens_in_window,
+                    # perf/* and mem/* per playbook/perf-metrics-schema.md.
+                    # Recorded on BOTH backends so GPU and TPU runs are
+                    # comparable on the same axes.
+                    "perf/step_time": _step_time,
+                    "perf/images_per_sec": (
+                        input_ids.size(0) * training_config.grad_acc_steps
+                        / max(_step_time, 1e-9)
+                    ),
+                }
+                _mem = backend.memory_info()
+                if _mem:
+                    log_dict["mem/used_gib"] = _mem.get("used_gib", 0.0)
+                    log_dict["mem/total_gib"] = _mem.get("total_gib", 0.0)
+                if backend.name == "tpu":
+                    # A RISING compile-cause count mid-run means a shape is
+                    # varying -- the single most useful XLA signal there is.
+                    try:
+                        import torch_xla.debug.metrics as _met
+                        log_dict["xla/compile_cause_count"] = (
+                            _met.metrics_report().count("CompileTime")
+                        )
+                    except Exception:  # noqa: BLE001 - never break a run to log
+                        pass
+
+                if "projector_token" in norm_cache:
+                    pn = norm_cache["projector_token"]
+                    log_dict["norms/projector_token_mean"] = pn.mean().item()
+                    log_dict["norms/projector_token_std"] = pn.std().item()
+                    log_dict["norms/projector_token_min"] = pn.min().item()
+                    log_dict["norms/projector_token_max"] = pn.max().item()
+
+                    emb_w = raw.get_input_embeddings().weight.detach().float()
+                    emb_norms = emb_w.norm(dim=-1)
+                    log_dict["norms/emb_matrix_mean"] = emb_norms.mean().item()
+                    log_dict["norms/emb_matrix_std"] = emb_norms.std().item()
+                    log_dict["norms/emb_matrix_min"] = emb_norms.min().item()
+                    log_dict["norms/emb_matrix_max"] = emb_norms.max().item()
+
+                # Checkpointing reads state_dict() off the device, so it is
+                # device work too: ALL ranks call it and `backend.save` decides
+                # who actually writes the bytes. Gating the call itself would
+                # deadlock at the first save -- 500 steps in, hours later.
+                if opt_step % training_config.save_steps == 0:
+                    save_checkpoint(checkpoint_dir, step + 1, model, optimizer,
+                                    lr_scheduler, backend=backend)
+
+                # --- host-side side effects: main only -----------------------
                 if is_main:
-                    log_dict = {
-                        "train/loss": accumulated_loss,
-                        "train/ce_loss": accumulated_ce_loss,
-                        "train/align_reg_loss": accumulated_align_reg_loss,
-                        "train/grad_norm": grad_norm.item(),
-                        "train/lr": lr_scheduler.get_last_lr()[0],
-                        "train/max_image_tokens": max_image_tokens_in_window,
-                    }
-
-                    if "projector_token" in norm_cache:
-                        pn = norm_cache["projector_token"]
-                        log_dict["norms/projector_token_mean"] = pn.mean().item()
-                        log_dict["norms/projector_token_std"] = pn.std().item()
-                        log_dict["norms/projector_token_min"] = pn.min().item()
-                        log_dict["norms/projector_token_max"] = pn.max().item()
-
-                        emb_w = raw.get_input_embeddings().weight.detach().float()
-                        emb_norms = emb_w.norm(dim=-1)
-                        log_dict["norms/emb_matrix_mean"] = emb_norms.mean().item()
-                        log_dict["norms/emb_matrix_std"] = emb_norms.std().item()
-                        log_dict["norms/emb_matrix_min"] = emb_norms.min().item()
-                        log_dict["norms/emb_matrix_max"] = emb_norms.max().item()
-
                     pbar.set_postfix(
                         loss=f"{accumulated_loss:.4f}",
                         lr=f"{lr_scheduler.get_last_lr()[0]:.2e}",
-                        gnorm=f"{grad_norm.item():.2f}",
+                        gnorm=f"{_grad_norm:.2f}",
                     )
 
                     if opt_step % training_config.logging_steps == 0:
@@ -255,26 +388,32 @@ def train(
                             f"LR {lr_scheduler.get_last_lr()[0]}"
                         )
 
-                    if opt_step % training_config.save_steps == 0:
-                        save_checkpoint(checkpoint_dir, step + 1, model, optimizer, lr_scheduler)
-
-                        if processor is not None:
-                            samples = generate_samples(
-                                model, batch, processor,
-                                compute_dtype, device,
-                            )
-                            for s in samples:
-                                generation_rows.append([opt_step, s["image"], s["prompt"], s["generation"]])
-                            table = wandb.Table(
-                                columns=["step", "image", "prompt", "generation"],
-                                data=generation_rows,
-                            )
-                            log_dict["generations"] = table
+                    # In-training sample generation is DISABLED on TPU.
+                    # `_prepare_cache_for_generation` forces a DynamicCache
+                    # whose shape grows by one every decoded token, so on XLA
+                    # each token is a new HLO program -- up to 256 compiles
+                    # per logged sample. That is tpu-diagnoser row 13, and it
+                    # would first fire at save_steps=500, hours in.
+                    # Generation belongs off-TPU or behind a static cache.
+                    # It stays main-only because it is heavy rank-0 device work
+                    # that the TPU path never reaches.
+                    if (opt_step % training_config.save_steps == 0
+                            and processor is not None and backend.name != "tpu"):
+                        samples = generate_samples(
+                            model, batch, processor,
+                            compute_dtype, device, backend,
+                        )
+                        for s in samples:
+                            generation_rows.append([opt_step, s["image"], s["prompt"], s["generation"]])
+                        table = wandb.Table(
+                            columns=["step", "image", "prompt", "generation"],
+                            data=generation_rows,
+                        )
+                        log_dict["generations"] = table
 
                     wandb.log(log_dict, step=opt_step)
 
-                if use_ddp:
-                    dist.barrier()
+                backend.barrier()
 
                 accumulated_loss = 0.0
                 accumulated_ce_loss = 0.0
@@ -282,28 +421,30 @@ def train(
                 max_image_tokens_in_window = 0
 
     hook_handle.remove()
-    if is_main:
-        save_checkpoint(checkpoint_dir, step + 1, model, optimizer, lr_scheduler)
-    if use_ddp:
-        dist.barrier()
+    # All ranks: same reason as the periodic save above -- reading state_dict()
+    # off the device is collective, and `backend.save` picks the writer.
+    save_checkpoint(checkpoint_dir, step + 1, model, optimizer, lr_scheduler,
+                    backend=backend)
+    backend.barrier()
     if is_main:
         print("Training complete")
 
 
 def run(cfg: DictConfig):
-    """Core training logic with DDP support."""
-    use_ddp = is_torchrun()
-    if use_ddp:
-        local_rank = setup_ddp()
-        rank = dist.get_rank()
-        world_size = dist.get_world_size()
-        device = torch.device(f"cuda:{local_rank}")
-    else:
-        local_rank = 0
-        rank = 0
-        world_size = 1
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    is_main = rank == 0
+    """Core training logic. Accelerator behaviour lives behind src/backend/."""
+    backend = create_backend()
+    backend.setup()
+    use_ddp = backend.name == "gpu" and backend.world_size > 1
+    device = backend.device
+    is_main = backend.is_main
+
+    # TWO divisors, deliberately not the same number:
+    #   world_size          = processes/hosts -> how the DataLoader splits
+    #   data_parallel_size  = chips           -> how the mesh shards on device
+    # On the v6e-16 that is 4 and 16. Conflating them is what made the old
+    # `batch_size % world_size` assert fail at 8 % 16.
+    world_size = backend.world_size
+    n_chips = backend.data_parallel_size
 
     # 1. Translate omegaconf nodes back to plain dictionaries
     training_dict = OmegaConf.to_container(cfg.training, resolve=True)
@@ -311,8 +452,7 @@ def run(cfg: DictConfig):
     # 2. Re-instantiate your configurations to maintain types downwards
     training_config = AlignmentConfig(**training_dict)
 
-    torch.manual_seed(training_config.seed)
-    torch.cuda.manual_seed_all(training_config.seed)
+    backend.manual_seed(training_config.seed)
     
     # Instantiate Model Config 
     model_config = TinyAyaVisionConfig.for_encoder(
@@ -320,20 +460,30 @@ def run(cfg: DictConfig):
         llm=cfg.llm
     )
 
-    # Compute per-GPU batch size from global batch size
-    assert training_config.batch_size % world_size == 0, (
-        f"batch_size ({training_config.batch_size}) must be "
-        f"divisible by world_size ({world_size})"
-    )
+    # Topology guards. Every failure these catch is otherwise SILENT -- a
+    # mis-sharded run hangs or trains on a malformed global batch rather than
+    # raising. Fail here, loudly, before a single chip is spent.
+    problems = backend.check_topology(global_batch=training_config.batch_size)
+    if problems:
+        raise ValueError(
+            "backend topology check failed:\n  - " + "\n  - ".join(problems)
+        )
     per_gpu_batch_size = training_config.batch_size // world_size
 
     if is_main:
-        print(f"{'DDP' if use_ddp else 'Single-GPU'}: world_size={world_size}, "
-              f"global_batch_size={training_config.batch_size}, "
-              f"per_gpu_batch_size={per_gpu_batch_size}")
+        mode = "DDP" if use_ddp else ("SPMD" if backend.name == "tpu" else "Single-GPU")
+        print(f"{mode} [{backend.describe()}]: hosts={world_size} chips={n_chips}, "
+              f"global_batch={training_config.batch_size}, "
+              f"per_host_batch={per_gpu_batch_size}, "
+              f"per_chip={training_config.batch_size // n_chips}")
 
     # Allow CLI-based resuming (e.g. `python train.py resume=xyz123`)
     resume_run_id = cfg.get("resume", None)
+    if not resume_run_id:
+        # Fall back to TAYAVISION_RESUME, which the launcher and the QR metadata
+        # carry so a recycled node self-heals. An explicit Hydra override always
+        # wins: command line beats environment.
+        resume_run_id = resolve_resume_run_id()
 
     if resume_run_id:
         run_id = resume_run_id
@@ -345,8 +495,7 @@ def run(cfg: DictConfig):
         checkpoint_dir.mkdir(parents=True, exist_ok=True)
         print(f"Run ID: {run_id}")
         print(f"Checkpoint dir: {checkpoint_dir}")
-    if use_ddp:
-        dist.barrier()
+    backend.barrier()
 
     config_path = checkpoint_dir / "config.json"
     if is_main and not config_path.exists():
@@ -364,7 +513,15 @@ def run(cfg: DictConfig):
             name=run_id,
             id=run_id.replace("-", ""),
             resume="allow",
-            config={**asdict(training_config), **model_config.to_dict()},
+            config={
+                **asdict(training_config),
+                **model_config.to_dict(),
+                # Without these a step_time on a chart is unattributable.
+                "backend": backend.name,
+                "data_parallel_size": backend.data_parallel_size,
+                "trc_profile": os.environ.get("TRC_PROFILE", ""),
+                "tpu_strategy": os.environ.get("TPU_STRATEGY", ""),
+            },
         )
 
     model = TinyAyaVisionForConditionalGeneration(
@@ -388,19 +545,73 @@ def run(cfg: DictConfig):
     model.vision_encoder.to(dtype=compute_dtype, non_blocking=True)
     model.language_model.to(dtype=compute_dtype, non_blocking=True)
 
-    model.language_model.gradient_checkpointing_enable()
+    # Gradient checkpointing is what keeps activations to per-layer boundaries,
+    # so it stays on for BOTH backends -- it is the difference between ~8.7 GiB
+    # and something that will not fit.
+    #
+    # BOTH torch checkpoint paths call `_get_device_module` ->
+    # `getattr(torch, "xla")`, and the non-reentrant one calls it
+    # UNCONDITIONALLY -- checkpoint.py:1476 runs twelve lines before the
+    # `if preserve_rng_state:` guard at :1488. So `preserve_rng_state=False`
+    # does NOT avoid it, and neither does `DefaultDeviceType.set_device_type()`.
+    # What makes this work is the `torch.xla` shim that `TPUBackend.setup()`
+    # installs (see `src/backend/tpu_backend.py::_register_xla_device_module`,
+    # called from `backend.setup()` above, long before this line).
+    #
+    # preserve_rng_state stays TRUE on XLA, and that is deliberate. The flag
+    # governs two independent things and only one of them involves the shim:
+    #
+    #   * device RNG -- gated on `getattr(device_module, "_initialized", False)`
+    #     (checkpoint.py:1496). The shim deliberately omits `_initialized`, so
+    #     this is always skipped, `had_device_in_fwd` stays False, `rng_devices`
+    #     stays `[]`, and `get_device_states` is never reached. Verified: with
+    #     `devices=[]`, `fork_rng` touches no attribute on the shim at all.
+    #   * CPU RNG -- `torch.get_rng_state()` / `torch.set_rng_state()` at
+    #     checkpoint.py:1489 and :1511. NOT gated on `_initialized`.
+    #
+    # So True costs nothing on XLA, keeps the CPU generator consistent between
+    # forward and recompute, and matches train_instruct.py / train_multilingual
+    # which both leave it at its default of True. Setting it False bought no
+    # memory and no speed -- it only made this branch silently diverge.
+    if backend.name == "tpu":
+        model.language_model.gradient_checkpointing_enable(
+            gradient_checkpointing_kwargs={"use_reentrant": False}
+        )
+    else:
+        model.language_model.gradient_checkpointing_enable()
 
-    if use_ddp:
-        model = DDP(model, device_ids=[local_rank])
-    model = torch.compile(model)
+    model = backend.wrap_model(model)
+    # torch.compile is a CUDA/inductor path. On XLA the graph is already
+    # traced+compiled by the runtime, and wrapping it here causes a second,
+    # conflicting compilation layer.
+    if backend.name == "gpu":
+        model = torch.compile(model)
 
     resume_step = 0
     if resume_run_id:
+        # A recycled slice comes back with an empty /models, so consult the
+        # gs:// mirror before concluding there is nothing to resume from --
+        # otherwise a preemption silently restarts training at step 0 while
+        # every log line still says "resume". No-op when SAVE_CKPT_DIR is unset
+        # or a local checkpoint is already present.
+        #
+        # Every rank fetches: each host has its own /models and must load the
+        # weights into its own replica.
+        fetch_checkpoint_from_gcs(checkpoint_dir)
+        backend.barrier()
+
         ckpt_path = find_latest_checkpoint(checkpoint_dir)
         if ckpt_path:
             if is_main:
                 print(f"Resuming from {ckpt_path}")
-            ckpt = torch.load(ckpt_path, map_location=device)
+            # torch has no XLA deserializer, so mapping straight onto the
+            # device raises "don't know how to restore data location of
+            # torch.storage.UntypedStorage (tagged with xla:0)" -- note the tag
+            # is the TARGET, not the file. Load to host and let
+            # `load_state_dict` copy into the already-placed parameters.
+            # GPU keeps `map_location=device` so the Modal path is unchanged.
+            map_location = "cpu" if backend.name == "tpu" else device
+            ckpt = torch.load(ckpt_path, map_location=map_location)
             raw_model = _unwrap_model(model)
             raw_model.multi_modal_projector.load_state_dict(ckpt["projector"])
             resume_step = ckpt["step"]
@@ -418,23 +629,36 @@ def run(cfg: DictConfig):
 
     full_dataset_len = len(dataset)
 
+    # SHARD-THEN-SKIP on TPU, never skip-then-shard.
+    #
+    # Subsetting first changes the dataset the sampler shards, so shard
+    # boundaries MOVE across a resume and hosts silently swap data. On spot
+    # capacity with qr_watch.sh recycling, resumes are routine.
+    #
+    # The GPU path keeps its original skip-then-shard order deliberately: it is
+    # the behaviour every published checkpoint was produced with, and changing
+    # it here would make this commit non-equivalent. It has the same latent
+    # issue under multi-GPU DDP resume -- tracked, not silently fixed.
+    batches_to_skip = 0
     samples_to_skip = resume_step * per_gpu_batch_size
-    if samples_to_skip > 0 and samples_to_skip < len(dataset):
+    if backend.name == "tpu":
+        if resume_step > 0:
+            batches_to_skip = resume_step
+            if is_main:
+                print(f"Resume: sharding the FULL dataset, then skipping "
+                      f"{batches_to_skip} batches per host")
+    elif samples_to_skip > 0 and samples_to_skip < len(dataset):
         remaining_indices = list(range(samples_to_skip, len(dataset)))
         dataset = torch.utils.data.Subset(dataset, remaining_indices)
         if is_main:
             print(f"Skipped {samples_to_skip} samples, {len(dataset)} remaining")
 
-    if use_ddp:
-        sampler = DistributedSampler(
-            dataset,
-            num_replicas=world_size,
-            rank=rank,
-            shuffle=True,
-            seed=training_config.seed,
-        )
-    else:
-        sampler = None
+    # Multi-host: shards across processes. Single-host: None.
+    sampler = backend.make_sampler(dataset, shuffle=True, seed=training_config.seed)
+
+    if sampler is not None:
+        print(f"[shard] process_index={backend.rank}/{backend.world_size} "
+              f"local_shard={len(sampler)} of dataset={len(dataset)}", flush=True)
 
     loader = torch.utils.data.DataLoader(
         dataset,
@@ -444,12 +668,24 @@ def run(cfg: DictConfig):
         collate_fn=partial(
             collate_fn,
             pad_token_id=processor.tokenizer.pad_token_id,
+            # XLA needs ONE sequence length or it recompiles per batch shape.
+            # None on GPU keeps dynamic padding, i.e. Modal is unchanged.
+            fixed_seq_len=(training_config.fixed_seq_len
+                           if backend.name == "tpu" else None),
+            # Lets the collate refuse to truncate image tokens away.
+            image_token_id=processor.image_token_id,
         ),
         num_workers=training_config.num_workers,
         pin_memory=True,
         persistent_workers=training_config.num_workers > 0,
         prefetch_factor=2 if training_config.num_workers > 0 else None,
-        drop_last=False,
+        # TPU: the ragged final batch is fatal, not merely wasteful. The sampler
+        # already drops its own tail (139,532 per host), but 139,532/64 leaves a
+        # final batch of 12 -- and 12 is not divisible by the 4 local chips, so
+        # ShardingSpec(minibatch=True) raises on it. It is also a new shape, i.e.
+        # an XLA recompile at every epoch boundary. Costs 12 samples per host.
+        # GPU keeps False so the Modal path is byte-identical.
+        drop_last=(backend.name == "tpu"),
     )
 
     raw_model = _unwrap_model(model)
@@ -467,7 +703,9 @@ def run(cfg: DictConfig):
 
     train(
         model=model,
-        dataloader=loader,
+        # MUST go through the backend: on TPU this is what shards the batch
+        # across chips (MpDeviceLoader input_sharding). Identity on GPU.
+        dataloader=backend.wrap_loader(loader),
         sampler=sampler,
         optimizer=opt,
         lr_scheduler=lr_scheduler,
@@ -478,12 +716,13 @@ def run(cfg: DictConfig):
         image_token_id=processor.image_token_id,
         processor=processor,
         step_offset=resume_step,
+        backend=backend,
+        batches_to_skip=batches_to_skip,
     )
 
     if is_main:
         wandb.finish()
-    if use_ddp:
-        cleanup_ddp()
+    backend.cleanup()
 
 
 @hydra.main(version_base="1.3", config_path="../config", config_name="config")

--- a/pipeline/train_instruct.py
+++ b/pipeline/train_instruct.py
@@ -43,7 +43,7 @@ from tqdm import tqdm
 from config.lora_config import LoraAdapterConfig
 from config.model_config import TinyAyaVisionConfig
 from config.training_config import InstructConfig
-from models.tiny_aya_vision import TinyAyaVisionForConditionalGeneration
+from models.tiny_aya_vision import TinyAyaVisionForConditionalGeneration  # noqa: F401  (importing the `models` package registers the HF Auto classes)
 from pipeline.data import InstructDataset, collate_fn
 from pipeline.apply_lora import apply_lora, get_lora_optimizer_groups
 from pipeline.utils import (

--- a/pipeline/train_multilingual.py
+++ b/pipeline/train_multilingual.py
@@ -47,7 +47,7 @@ import wandb
 from config.lora_config import LoraAdapterConfig
 from config.model_config import TinyAyaVisionConfig
 from config.multilingual_config import MultilingualInstructConfig
-from models.tiny_aya_vision import TinyAyaVisionForConditionalGeneration
+from models.tiny_aya_vision import TinyAyaVisionForConditionalGeneration  # noqa: F401  (importing the `models` package registers the HF Auto classes)
 from pipeline.data import collate_fn
 from pipeline.multilingual_data import MultilingualInstructDataset
 from pipeline.apply_lora import apply_lora, get_lora_optimizer_groups
@@ -114,7 +114,7 @@ def main(
         print(f"{'DDP' if use_ddp else 'Single-GPU'}: world_size={world_size}, "
               f"global_batch_size={training_config.batch_size}, "
               f"per_gpu_batch_size={per_gpu_batch_size}")
-        print(f"\nMultilingual mixing config:")
+        print("\nMultilingual mixing config:")
         print(f"  Total samples: {training_config.total_samples}")
         print(f"  English ratio: {training_config.english_ratio}")
         print(f"  Temperature: {training_config.temperature}")
@@ -143,8 +143,15 @@ def main(
             }, f, indent=2)
 
     if is_main:
+        # Was hardcoded to "tayavision-multilingual", which silently ignored any
+        # override. On TPU that routed bring-up metrics into a GPU *results*
+        # project. `cfg` is not in scope here (it lives in run(), not main()), so
+        # the env var is the override channel -- which is also what
+        # scripts/tpu/train_launcher.sh sets from .env. The literal stays as the
+        # fallback, so existing Modal invocations are byte-for-byte unchanged.
         wandb.init(
-            project="tayavision-multilingual",
+            project=os.environ.get("WANDB_PROJECT") or "tayavision-multilingual",
+            entity=os.environ.get("WANDB_ENTITY"),
             name=run_id,
             id=run_id.replace("-", ""),
             resume="allow",

--- a/pipeline/utils.py
+++ b/pipeline/utils.py
@@ -2,6 +2,8 @@
 
 import os
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 import torch
@@ -9,6 +11,192 @@ import torch.distributed as dist
 
 from models import save_for_inference
 from src.processing import TinyAyaVisionProcessor
+
+# Generous: a ~140 MB projector+optimizer checkpoint to a co-located bucket
+# takes seconds. The timeout exists so a wedged network cannot stall training
+# indefinitely, not to bound normal operation.
+GCS_TIMEOUT_S = 600
+
+
+def gcs_checkpoint_root() -> str | None:
+    """The `gs://` prefix checkpoints mirror to, or None when not configured.
+
+    Reads `SAVE_CKPT_DIR`. Until this function existed that variable reached
+    `scripts/tpu/*.sh` -- deploy warnings, queued-resource metadata, the
+    `qr_watch.sh` durability gate -- but NOT the training code. Every surface
+    therefore reported durability as armed while `save_checkpoint` wrote to
+    node-local `/models`, which a preemption destroys. Anything that is not a
+    `gs://` URI is ignored, so the Modal/GPU path is unaffected.
+    """
+    root = os.environ.get("SAVE_CKPT_DIR", "").strip().rstrip("/")
+    return root if root.startswith("gs://") else None
+
+
+def _gcloud_storage(*args: str) -> tuple[bool, str, str]:
+    """Run `gcloud storage <args>`. Returns (ok, stdout, error_message).
+
+    Shelling out rather than adding `google-cloud-storage`: every script that
+    sets `SAVE_CKPT_DIR` already requires the gcloud CLI, so this introduces no
+    dependency that the path did not already have.
+    """
+    exe = shutil.which("gcloud")
+    if exe is None:
+        return False, "", "gcloud not on PATH"
+    try:
+        proc = subprocess.run(
+            [exe, "storage", *args],
+            capture_output=True, text=True, timeout=GCS_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "", f"timed out after {GCS_TIMEOUT_S}s"
+    except OSError as exc:
+        return False, "", str(exc)
+    if proc.returncode != 0:
+        msg = (proc.stderr or proc.stdout).strip()
+        return False, "", msg.splitlines()[-1] if msg else f"exit {proc.returncode}"
+    return True, proc.stdout, ""
+
+
+def _checkpoint_step(name: str) -> int:
+    """Step number encoded in a checkpoint filename, or -1."""
+    match = re.search(r"checkpoint_(\d+)\.pt$", str(name))
+    return int(match.group(1)) if match else -1
+
+
+def mirror_checkpoint_to_gcs(local_path: Path) -> bool:
+    """Copy a just-written checkpoint to `SAVE_CKPT_DIR/<run_id>/`.
+
+    Call from the rank that actually wrote the file, and only that rank. This
+    is safe despite the SPMD rule that device work must not be rank-gated:
+    uploading a file that already exists on disk is pure host I/O and issues no
+    collective. It does stall the mesh for the upload -- the other ranks run
+    ahead and block at the next collective until this one arrives -- which at
+    ~seconds per `save_steps` interval is a rounding error against the run.
+    """
+    root = gcs_checkpoint_root()
+    if root is None:
+        return False
+    # /models/<run_id>/checkpoint_N.pt -> <root>/<run_id>/checkpoint_N.pt,
+    # matching the layout the interim rsync loop already produced.
+    dest = f"{root}/{local_path.parent.name}/{local_path.name}"
+    ok, _, err = _gcloud_storage("cp", str(local_path), dest)
+    if ok:
+        print(f"Mirrored checkpoint to {dest}", flush=True)
+        return True
+    # Deliberately does NOT raise. Killing a multi-hour run over a transient
+    # bucket error is worse than losing one mirror. But it is loud, because a
+    # silent failure here means the run only *looks* durable.
+    print(
+        f"WARNING: checkpoint NOT mirrored to {dest} ({err}). "
+        f"{local_path} exists only on node-local disk and will not survive "
+        "a preemption.",
+        flush=True,
+    )
+    return False
+
+
+# Values that mean "do not resume". Anything else is either `auto` or a literal
+# run id, so a typo resolves to a run id that does not exist and reports
+# "no mirrored checkpoints" rather than silently starting over.
+_RESUME_OFF = frozenset({"", "off", "none", "no", "0", "false"})
+
+
+def latest_mirrored_run_id() -> str | None:
+    """Run id of the most recently mirrored checkpoint under `SAVE_CKPT_DIR`.
+
+    Deterministic across hosts: it is a pure function of the bucket listing, and
+    at startup no run is writing to it. Should it ever disagree between hosts,
+    `fetch_checkpoint_from_gcs` logs the exact object it pulled on every rank,
+    so the divergence is greppable rather than silent.
+    """
+    root = gcs_checkpoint_root()
+    if root is None:
+        print("TAYAVISION_RESUME=auto but SAVE_CKPT_DIR is not a gs:// URI -- "
+              "nothing durable to resume from. Starting fresh.", flush=True)
+        return None
+    ok, listing, err = _gcloud_storage("ls", "-l", f"{root}/*/checkpoint_*.pt")
+    newest_ts, newest_url = "", None
+    if ok:
+        for line in listing.splitlines():
+            # "<size>  <ISO-8601>  gs://<root>/<run_id>/checkpoint_<n>.pt".
+            # ISO-8601 sorts lexicographically, so no date parsing is needed.
+            # The trailing "TOTAL: ..." summary has no gs:// field and is skipped.
+            fields = line.split()
+            if len(fields) < 3 or not fields[-1].startswith("gs://"):
+                continue
+            if fields[-2] > newest_ts:
+                newest_ts, newest_url = fields[-2], fields[-1]
+    if newest_url is None:
+        print(f"TAYAVISION_RESUME=auto found no checkpoints under {root} "
+              f"({err or 'empty'}). Starting fresh.", flush=True)
+        return None
+    run_id = newest_url.rstrip("/").split("/")[-2]
+    print(f"TAYAVISION_RESUME=auto -> run {run_id} "
+          f"(newest mirrored checkpoint, {newest_ts})", flush=True)
+    return run_id
+
+
+def resolve_resume_run_id() -> str | None:
+    """Translate `TAYAVISION_RESUME` into a run id, or None to start fresh.
+
+    `off`/`none`/`no`/`0`/`false`/unset -> None
+    `auto`                              -> newest run id under SAVE_CKPT_DIR
+    anything else                       -> taken as a literal run id
+
+    Until this existed the variable was inert: `train_launcher.sh:93` printed
+    `resume=${TAYAVISION_RESUME:-auto}` and nothing read it, so every surface --
+    the launcher banner, the QR metadata, `SPEC.md` section 5 -- described a
+    self-healing resume that could not happen. It is the same shape of defect
+    `SAVE_CKPT_DIR` had: a knob that reads as wired and is not.
+
+    Callers must let an explicit Hydra `resume=<uuid>` win over this, because
+    the command line beating the environment is this repo's config convention.
+
+    **`auto` is only safe where the config is fixed.** It resumes whatever ran
+    last, so on the boot/recycle path -- same QR metadata, therefore same
+    overrides by construction -- it is exactly right. On a human redeploy, where
+    the overrides change between invocations, it would load run A's optimizer
+    state and step count into run B's config, silently. That is why the default
+    is set per caller (`launch_qr.sh`/`startup_script.sh` -> auto,
+    `deploy_tarball.sh` -> off) rather than once in `_lib.sh`.
+    """
+    raw = os.environ.get("TAYAVISION_RESUME", "").strip()
+    if raw.lower() in _RESUME_OFF:
+        return None
+    if raw.lower() != "auto":
+        return raw
+    return latest_mirrored_run_id()
+
+
+def fetch_checkpoint_from_gcs(checkpoint_dir: Path) -> Path | None:
+    """Pull the newest mirrored checkpoint for this run into `checkpoint_dir`.
+
+    Call on EVERY rank. Each host has its own `/models` and each must load the
+    same weights into its own replica; fetching on rank 0 alone would leave the
+    others with a freshly-initialised projector -- divergent state, and silent.
+
+    A local checkpoint always wins, so this is a no-op on a slice that never
+    went away. It only does work after a recycle, which is exactly the case
+    `find_latest_checkpoint` would otherwise report as "start from scratch".
+    """
+    root = gcs_checkpoint_root()
+    if root is None or find_latest_checkpoint(checkpoint_dir) is not None:
+        return None
+    prefix = f"{root}/{checkpoint_dir.name}"
+    ok, listing, err = _gcloud_storage("ls", f"{prefix}/checkpoint_*.pt")
+    remote = [u for u in listing.split() if u.endswith(".pt")] if ok else []
+    if not remote:
+        print(f"No mirrored checkpoints under {prefix} ({err or 'empty'})", flush=True)
+        return None
+    newest = max(remote, key=_checkpoint_step)
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    ok, _, err = _gcloud_storage("cp", newest, str(checkpoint_dir))
+    if not ok:
+        print(f"WARNING: failed to fetch {newest} ({err})", flush=True)
+        return None
+    local = checkpoint_dir / Path(newest).name
+    print(f"Fetched {newest} -> {local}", flush=True)
+    return local
 
 
 def is_torchrun() -> bool:
@@ -40,12 +228,19 @@ def _unwrap_model(model):
     return raw
 
 
-def save_checkpoint(checkpoint_dir, step, model, optimizer, lr_scheduler, save_lora=False):
+def save_checkpoint(checkpoint_dir, step, model, optimizer, lr_scheduler,
+                    save_lora=False, backend=None):
     """Save a training checkpoint to disk.
 
     Always saves the projector state dict, optimizer, and LR scheduler.
     When ``save_lora=True``, also saves LoRA adapter weights from the
     language model (used by instruct / multilingual pipelines).
+
+    ``backend`` routes the write through the accelerator seam. Pass it and call
+    this from EVERY rank: assembling the state dict reads tensors off the
+    device, which on SPMD is collective work that every rank must join. The
+    backend decides who writes. Omitting it keeps the original single-process
+    behaviour, which is what the instruct/multilingual pipelines still use.
     """
     save_path = checkpoint_dir / f"checkpoint_{step}.pt"
     raw_model = _unwrap_model(model)
@@ -60,8 +255,18 @@ def save_checkpoint(checkpoint_dir, step, model, optimizer, lr_scheduler, save_l
             k: v for k, v in raw_model.language_model.state_dict().items()
             if "lora_" in k
         }
-    torch.save(state, save_path)
-    print(f"Saved checkpoint to {save_path}")
+    if backend is None:
+        torch.save(state, save_path)
+        wrote = True
+    else:
+        backend.save(state, save_path)
+        wrote = backend.is_main
+
+    # Only the rank that wrote the bytes mirrors them; see
+    # `mirror_checkpoint_to_gcs` on why rank-gating is safe here specifically.
+    if wrote:
+        print(f"Saved checkpoint to {save_path}")
+        mirror_checkpoint_to_gcs(save_path)
 
 
 def find_latest_checkpoint(checkpoint_dir: Path) -> Path | None:
@@ -69,10 +274,7 @@ def find_latest_checkpoint(checkpoint_dir: Path) -> Path | None:
     checkpoints = list(checkpoint_dir.glob("checkpoint_*.pt"))
     if not checkpoints:
         return None
-    def extract_step(p):
-        m = re.search(r"checkpoint_(\d+)\.pt$", p.name)
-        return int(m.group(1)) if m else -1
-    return max(checkpoints, key=extract_step)
+    return max(checkpoints, key=lambda p: _checkpoint_step(p.name))
 
 
 def save_hf_model(model, processor: TinyAyaVisionProcessor, checkpoint_dir: Path, training_config=None) -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,30 @@ dev = [
     "ruff>=0.8.0",
 ]
 
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+# Ruff's default set, pinned explicitly so a ruff upgrade cannot silently
+# change what CI gates on. Widening this (W, I, UP, B, SIM add ~120 findings
+# between them) is a deliberate follow-up, not a drive-by.
+select = ["E4", "E7", "E9", "F"]
+
+[tool.ruff.lint.per-file-ignores]
+# These two set TORCHINDUCTOR_CACHE_DIR and extend sys.path before importing
+# torch and the local packages. The ordering is load-bearing: the env var has
+# to be set before inductor initialises, so the imports genuinely cannot move
+# to the top of the file.
+"pipeline/train_instruct.py" = ["E402"]
+"pipeline/train_multilingual.py" = ["E402"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "requires_gpu: test needs a CUDA device (auto-skipped when unavailable)",
+]
+
 [[tool.uv.index]]
 name = "pytorch-cu124"
 url = "https://download.pytorch.org/whl/cu124"

--- a/scripts/ci/check_backend_seam.sh
+++ b/scripts/ci/check_backend_seam.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# check_backend_seam.sh -- enforce the TPU/GPU separation seam.
+#
+# WHY THIS EXISTS
+# ---------------
+# The repo is dual-backend. Shared code in src/, models/, pipeline/, and config/
+# must import cleanly on a CPU or GPU box that has no torch_xla installed. The
+# ONLY module allowed to `import torch_xla` at module scope is
+# src/backend/tpu_backend.py.
+#
+# A *module-level* torch_xla import anywhere else drags libtpu into the import
+# graph. That breaks every Modal/GPU run and all 129 tests -- and it breaks them
+# at import time, so the failure lands nowhere near its cause.
+# models/__init__.py matters most: it registers the HF Auto classes at import and
+# is pulled in by every eval script.
+#
+# Lazy (in-function, indented) `import torch_xla` inside a TPU-only code path is
+# fine -- it only fires when actually running on TPU. This check flags column-0
+# (module-level) imports only.
+#
+# Usage:  bash scripts/ci/check_backend_seam.sh
+# Exit 0 = seam holds; exit 1 = a module-level torch_xla import leaked.
+set -uo pipefail
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+TREES=(src models pipeline config evaluation)
+ALLOWED="src/backend/tpu_backend.py"
+
+hits="$(grep -rnE '^(import torch_xla|from torch_xla)' "${TREES[@]}" 2>/dev/null \
+        | grep -v "^${ALLOWED}:" || true)"
+
+if [ -n "$hits" ]; then
+  echo "FAIL: module-level torch_xla import outside ${ALLOWED} --" >&2
+  echo "      move it into src/backend/tpu_backend.py, or make it a lazy" >&2
+  echo "      in-function import guarded by the TPU code path." >&2
+  echo "$hits" >&2
+  exit 1
+fi
+
+# The allowed module must actually exist, or this check silently passes forever
+# on a repo where the seam was deleted.
+if [ ! -f "$ALLOWED" ]; then
+  echo "FAIL: $ALLOWED is missing -- the seam has no TPU implementation." >&2
+  exit 1
+fi
+
+echo "backend-seam-ok (torch_xla confined to ${ALLOWED}; trees: ${TREES[*]})"

--- a/scripts/download_multilingual.py
+++ b/scripts/download_multilingual.py
@@ -33,7 +33,7 @@ from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_compl
 from pathlib import Path
 from threading import Lock
 
-from huggingface_hub import hf_hub_download, HfApi
+from huggingface_hub import HfApi
 
 
 PANGEA_REPO = "neulab/PangeaInstruct"
@@ -88,7 +88,7 @@ def _retry_request(request_fn, max_retries=_MAX_RETRIES):
                  f"(attempt {attempt + 1}/{max_retries}) ...")
             time.sleep(wait)
         except (requests.exceptions.ConnectionError,
-                requests.exceptions.Timeout) as exc:
+                requests.exceptions.Timeout):
             if attempt == max_retries:
                 raise
             wait = _BACKOFF_BASE * (2 ** attempt)

--- a/scripts/merge_weights.py
+++ b/scripts/merge_weights.py
@@ -380,7 +380,6 @@ def _stream_merge_one_alpha(
     output_dir.mkdir(parents=True, exist_ok=True)
     _copy_hf_metadata_files(finetuned_dir, output_dir)
 
-    orig_embed = "model.embed_tokens.weight"
     ft_embed = f"{LLM_PREFIX}model.embed_tokens.weight"
     ft_lm_head = f"{LLM_PREFIX}lm_head.weight"
     has_ft_embed = ft_embed in finetuned_map

--- a/scripts/modal_download_multilingual_data.py
+++ b/scripts/modal_download_multilingual_data.py
@@ -61,8 +61,6 @@ script. Use scripts/modal_download.py for LLaVA-Pretrain which includes COCO.
 
 from __future__ import annotations
 
-import csv
-import json
 import os
 import shutil
 import subprocess
@@ -70,7 +68,6 @@ import tarfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from threading import Lock
-from typing import Literal
 
 import modal
 
@@ -220,7 +217,7 @@ def _retry_request(request_fn, max_retries: int = _MAX_RETRIES):
             wait = _BACKOFF_BASE * (2 ** attempt)
             _log(f"    HTTP {status}, retrying in {wait}s (attempt {attempt + 1}/{max_retries})...")
             time.sleep(wait)
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             if attempt == max_retries:
                 raise
             wait = _BACKOFF_BASE * (2 ** attempt)
@@ -365,7 +362,9 @@ def download_json_dataset(
 
         # Use hf_hub_download for authentication support (gated datasets)
         try:
-            downloaded_path = hf_hub_download(
+            # Called for its side effect (writes into local_dir); the returned
+            # cache path is not used.
+            hf_hub_download(
                 config["hf_repo"],
                 filename,
                 repo_type="dataset",
@@ -417,7 +416,7 @@ def download_hf_dataset(
     except Exception as e:
         _log(f"[{config['name']}] Failed: {e}")
         if config.get("gated"):
-            _log(f"  This is a gated dataset. Provide --hf-secret with your HF token.")
+            _log("  This is a gated dataset. Provide --hf-secret with your HF token.")
         return False
 
 
@@ -452,7 +451,9 @@ def download_mvl_sib(output_base: Path, hf_token: str | None = None) -> bool:
         for idx in range(10):
             img_name = f"{cat}_{idx}.jpg"
             try:
-                img_path = hf_hub_download(
+                # Called for its side effect (writes into images_dir); the
+                # returned cache path is not used.
+                hf_hub_download(
                     config["hf_repo"],
                     f"data/images/sib200/{img_name}",
                     repo_type="dataset",

--- a/scripts/modal_eval_checkpoint_en.py
+++ b/scripts/modal_eval_checkpoint_en.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import threading
-import time
 import uuid
 
 import modal

--- a/scripts/tpu/README.md
+++ b/scripts/tpu/README.md
@@ -1,0 +1,101 @@
+# `scripts/tpu/`
+
+Provisioning and supervision for Tiny Aya Vision on TRC Cloud TPU.
+
+> **These scripts cannot train this model yet.** `pipeline/train_*.py` is DDP + CUDA.
+> `TAYAVISION_ENTRYPOINT` defaults to `tpu_smoke.py`, which proves the control plane on
+> real silicon. See `.claude/orchestration/SPEC.md` §9. Design docs live in
+> `.claude/orchestration/`; the operator guide is `docs/tpu/tpu-runbook.md`.
+
+## Files
+
+| File | Where it runs | Purpose |
+|---|---|---|
+| `_lib.sh` | everywhere (sourced) | `load_env_file`, `notify`, `make_code_tarball`, `profile_spec`, cross-region warning |
+| `setup_gcp.sh` | workstation, once | APIs, `gs://tayavision-eu`, IAM |
+| `launch_qr.sh` | workstation | Create the queued resource; carries all knobs as VM metadata |
+| `launch_spot.sh` | workstation | `TRC_PROFILE` wrapper with `SPOT=1`. **The normal entry point.** |
+| `startup_script.sh` | TPU VM, every boot | apt → uv → tarball → `uv sync` (CPU torch) + `uv pip install torch_xla[tpu]` → libpython link → tmux `train` |
+| `train_launcher.sh` | TPU VM, in tmux | Runs the entrypoint; emits the markers every watcher greps |
+| `deploy_tarball.sh` | workstation | **T2**: push code to a live slice and relaunch. No QR change. |
+| `qr_watch.sh` | workstation, tmux | **T3**: recycle on preemption, gated on `gs://` checkpoints |
+| `ops.sh` | workstation | `preflight`, `status`, `tail-logs`, `attach`, `ssh`, `delete` |
+| `tpu_smoke.py` | TPU VM | The default entrypoint. Not training. |
+
+Not ported from the sibling repos: sweep runners, VM coordinators, provisioning races, and
+supervisor VMs. There is nothing to sweep until the backend seam lands.
+
+## Environment
+
+Precedence: **shell env > repo-root `.env` > script defaults.**
+
+| Variable | Default | Notes |
+|---|---|---|
+| `TRC_PROFILE` | `v6e-8-eu` | The only profile not blocked by the external-IP cap |
+| `PROJECT_ID` | `ml-pipelines-315702` | The TRC grant project |
+| `BUCKET` | `gs://tayavision-eu` | **One bucket.** Non-EU zones pay egress. |
+| `TAYAVISION_ENTRYPOINT` | `scripts/tpu/tpu_smoke.py` | Repo-relative, passed to `uv run python -u` |
+| `TAYAVISION_HYDRA_OVERRIDES` | `""` | Appended verbatim, e.g. `vision=siglip llm=base` |
+| `TAYAVISION_RESUME` | **per caller** — `auto` for `launch_qr.sh`/boot, `off` for `deploy_tarball.sh` | See below |
+| `TPU_STRATEGY` | `replicated` | Not FSDPv2 — see `TPU_OPTIMIZATION_SPEC.md` §4 |
+| `SAVE_CKPT_DIR` | unset | **Must be `gs://`** for T3 auto-recycle *and* for `TAYAVISION_RESUME=auto` |
+
+### `TAYAVISION_RESUME`
+
+| Value | Effect |
+|---|---|
+| `off` / `none` / `no` / `0` / `false` / unset | Start fresh |
+| `auto` | Resume the run with the **most recently mirrored** checkpoint under `SAVE_CKPT_DIR` |
+| `<run-id>` | Resume that run specifically |
+
+An explicit Hydra `resume=<run-id>` on the command line beats this variable.
+
+**Why the default differs by caller.** `auto` resumes whatever ran last. On the
+boot/recycle path that is exactly right: the QR metadata is replayed verbatim, so the
+overrides cannot have drifted. On a human `deploy_tarball.sh` the overrides *do* change
+between invocations, and resuming would load the previous run's optimizer state, LR
+schedule position, and step count into a different config — silently. So `deploy_tarball.sh`
+defaults to `off`; pass `TAYAVISION_RESUME=auto` explicitly when you mean it.
+
+`auto` needs a `gs://` `SAVE_CKPT_DIR`: node-local checkpoints are exactly what a recycle
+destroys, so there would be nothing to find.
+| `MAX_RESUBMITS` | `20` | T3 budget |
+| `HF_TOKEN` | — | **Required.** The model repos are gated. |
+| `NTFY_TOPIC` | — | Absent → `notify()` is a silent no-op |
+
+## Typical flow
+
+```bash
+cp .env.example .env              # fill HF_TOKEN at minimum
+bash scripts/tpu/setup_gcp.sh     # once
+bash scripts/tpu/ops.sh preflight
+
+TRC_PROFILE=v6e-8-eu \
+SAVE_CKPT_DIR=gs://tayavision-eu/checkpoints/smoke-01 \
+bash scripts/tpu/launch_spot.sh
+
+tmux new -d -s qrwatch-tayavision 'bash scripts/tpu/qr_watch.sh'
+bash scripts/tpu/ops.sh status
+bash scripts/tpu/ops.sh tail-logs
+# ... iterate with deploy_tarball.sh ...
+bash scripts/tpu/ops.sh delete    # a live slice bills whether or not it is busy
+```
+
+## What these scripts do NOT do
+
+- **Train the model.** The entrypoint is the last mile and it is not built.
+- **Decide cross-region tradeoffs.** `launch_spot.sh` warns on a non-EU profile against
+  the single EU bucket; it does not block. That call is the operator's.
+- **Recycle without durable checkpoints.** `qr_watch.sh` refuses and says why.
+- **Sweep, race zones, or run a supervisor VM.**
+- **Touch the Modal path.** That is separate, working, and authoritative.
+
+## Dry runs
+
+`launch_qr.sh` and `deploy_tarball.sh` both honour `DRY_RUN=1` and print what they would
+do without spending capacity:
+
+```bash
+DRY_RUN=1 TRC_PROFILE=v6e-8-eu    bash scripts/tpu/launch_spot.sh
+DRY_RUN=1 TRC_PROFILE=v6e-64-ue1d bash scripts/tpu/launch_spot.sh   # prints the egress warning
+```

--- a/scripts/tpu/_lib.sh
+++ b/scripts/tpu/_lib.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# _lib.sh -- shared helpers for the TPU scripts. SOURCE THIS, do not execute it.
+#
+#   source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+#
+# Adapted from llm-architectures/scripts/tpu/_lib.sh, itself ported from
+# tinyaya-stage2-scale. See .claude/orchestration/README.md for provenance.
+
+# ---------------------------------------------------------------------------
+# Repo root, regardless of where the caller ran from.
+# ---------------------------------------------------------------------------
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export REPO_ROOT
+
+# ---------------------------------------------------------------------------
+# Defaults. Precedence: shell env > repo-root .env > these.
+# ---------------------------------------------------------------------------
+: "${PROJECT_ID:=ml-pipelines-315702}"
+: "${TRC_PROFILE:=v6e-8-eu}"
+: "${BUCKET:=gs://tayavision-eu}"
+: "${CODE_PREFIX:=code}"
+: "${TMUX_SESSION:=train}"
+: "${REPO_DIR:=/home/\$USER/expedition-tayavision}"
+: "${TAYAVISION_ENTRYPOINT:=scripts/tpu/tpu_smoke.py}"
+: "${TAYAVISION_HYDRA_OVERRIDES:=}"
+# TAYAVISION_RESUME is deliberately NOT defaulted here. `auto` resumes whatever
+# ran last, which is right on the boot/recycle path (same QR metadata, so the
+# same overrides by construction) and wrong on a human redeploy, where the
+# overrides change between invocations and resuming would load the previous
+# run's optimizer state and step count into a different config -- silently.
+# So each caller sets its own default: launch_qr.sh and startup_script.sh use
+# `auto`, deploy_tarball.sh uses `off`. Every reference must use `${VAR:-...}`,
+# since callers run under `set -u`.
+: "${TPU_STRATEGY:=replicated}"
+: "${MAX_RESUBMITS:=20}"
+: "${POLL_SECONDS:=300}"
+: "${COOLDOWN_SECONDS:=120}"
+: "${HEARTBEAT_SECONDS:=7200}"
+
+# ---------------------------------------------------------------------------
+# load_env_file -- read KEY=VALUE without clobbering anything already set.
+#
+# Deliberately does NOT overwrite an exported shell var: that is what makes
+# `FOO=bar bash script.sh` beat the .env file.
+# ---------------------------------------------------------------------------
+load_env_file() {
+  local f="${1:-$REPO_ROOT/.env}"
+  [ -f "$f" ] || return 0
+  local line key val
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in ''|'#'*) continue ;; esac
+    case "$line" in *=*) ;; *) continue ;; esac
+    key="${line%%=*}"
+    val="${line#*=}"
+    key="$(printf '%s' "$key" | tr -d '[:space:]')"
+    # strip one layer of surrounding quotes
+    val="${val%\"}"; val="${val#\"}"
+    val="${val%\'}"; val="${val#\'}"
+    [ -n "$key" ] || continue
+    if [ -z "${!key:-}" ]; then
+      export "$key=$val"
+    fi
+  done < "$f"
+}
+
+# ---------------------------------------------------------------------------
+# notify -- push an event to ntfy.
+#
+# A NO-OP when NTFY_TOPIC is unset, and it NEVER fails its caller. That is what
+# lets every call site stay unconditional: a first run with no .env works, it is
+# just deaf. See .claude/orchestration/playbook/event-taxonomy.md.
+# ---------------------------------------------------------------------------
+notify() {
+  local msg="$1"
+  local title="${2:-tayavision}"
+  [ -n "${NTFY_TOPIC:-}" ] || return 0
+  curl -fsS -m 10 \
+    -H "Title: $title" \
+    -d "$msg" \
+    "https://ntfy.sh/${NTFY_TOPIC}" >/dev/null 2>&1 || true
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# log -- timestamped line to stdout.
+# ---------------------------------------------------------------------------
+log() { printf '[%s] %s\n' "$(date -Is)" "$*"; }
+
+# ---------------------------------------------------------------------------
+# bucket_for_profile -- Tiny Aya Vision uses ONE bucket, gs://tayavision-eu.
+#
+# So this does not map profile -> bucket; it reports whether the profile's zone
+# is co-located with the single bucket, and warns when it is not. A cross-region
+# profile still works -- it just pays egress on every checkpoint write and every
+# code-tarball pull. That is a deliberate operator choice, not something a
+# script should make silently or block outright.
+# ---------------------------------------------------------------------------
+bucket_region_ok() {
+  local zone="$1"
+  case "$zone" in
+    europe-west4-*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+warn_if_cross_region() {
+  local zone="$1"
+  if ! bucket_region_ok "$zone"; then
+    log "WARNING: zone '$zone' is NOT co-located with $BUCKET (europe-west4)."
+    log "         Every checkpoint write and code pull crosses regions and pays egress."
+    log "         See docs/tpu/tpu-trc-allocation.md 'Bucket co-location'."
+    log "         Either accept it for a short run, or stand up a region-paired"
+    log "         bucket and point SAVE_CKPT_DIR at it."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# profile_spec -- TRC_PROFILE -> "ACCEL_TYPE ZONE RUNTIME NODE_ID QR_NAME HOSTS"
+#
+# Table is authoritative in docs/tpu/tpu-trc-allocation.md; keep them in sync.
+# ---------------------------------------------------------------------------
+profile_spec() {
+  case "${1:-$TRC_PROFILE}" in
+    v6e-8-eu)     echo "v6e-8         europe-west4-a v2-alpha-tpuv6e      tayavision-v6e8  tayavision-v6e8-qr  1" ;;
+    # v6e-16 host count MEASURED 2026-07-25: 4 network endpoints, i.e. 4 chips
+    # per host, not the 8 the public topology tables imply. The others are
+    # derived from that ratio and remain unverified -- NUM_HOSTS is cosmetic
+    # (fan-out uses --worker=all), so a wrong value misreports but never breaks.
+    v6e-16-ew4a)  echo "v6e-16        europe-west4-a v2-alpha-tpuv6e      tayavision-v6e16 tayavision-v6e16-qr 4" ;;
+    v6e-32-ew4a)  echo "v6e-32        europe-west4-a v2-alpha-tpuv6e      tayavision-v6e32 tayavision-v6e32-qr 8" ;;
+    v6e-64-ew4a)  echo "v6e-64        europe-west4-a v2-alpha-tpuv6e      tayavision-v6e64 tayavision-v6e64-qr 16" ;;
+    v5e-64-ew4b)  echo "v5litepod-64  europe-west4-b v2-alpha-tpuv5-lite  tayavision-v5e64 tayavision-v5e64-qr 16" ;;
+    v6e-64-ue1d)  echo "v6e-64        us-east1-d     v2-alpha-tpuv6e      tayavision-v6e64 tayavision-v6e64-qr 8" ;;
+    v5e-64-uc1a)  echo "v5litepod-64  us-central1-a  v2-alpha-tpuv5-lite  tayavision-v5e64 tayavision-v5e64-qr 16" ;;
+    v4-32-uc2b)   echo "v4-32         us-central2-b  tpu-ubuntu2204-base  tayavision-v4-32 tayavision-v4-32-qr 4" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Populate ACCEL_TYPE/ZONE/RUNTIME/NODE_ID/QR_NAME/NUM_HOSTS from TRC_PROFILE,
+# without clobbering anything the caller already set.
+resolve_profile() {
+  local spec
+  if ! spec="$(profile_spec "$TRC_PROFILE")"; then
+    log "ERROR: unknown TRC_PROFILE '$TRC_PROFILE'."
+    log "       EU (co-located): v6e-8-eu v6e-16-ew4a v6e-32-ew4a v6e-64-ew4a v5e-64-ew4b"
+    log "       US (cross-region, pays egress): v6e-64-ue1d v5e-64-uc1a v4-32-uc2b"
+    return 1
+  fi
+  # shellcheck disable=SC2086
+  set -- $spec
+  : "${ACCEL_TYPE:=$1}"
+  : "${ZONE:=$2}"
+  : "${RUNTIME:=$3}"
+  : "${NODE_ID:=$4}"
+  : "${QR_NAME:=$5}"
+  : "${NUM_HOSTS:=$6}"
+  export ACCEL_TYPE ZONE RUNTIME NODE_ID QR_NAME NUM_HOSTS
+}
+
+# ---------------------------------------------------------------------------
+# make_code_tarball -- tar the working tree INCLUDING the gitignored .env.
+#
+# The .env inclusion is the entire reason there is no git clone in this flow:
+# CohereLabs/tiny-aya-* is a GATED repo, and HF_TOKEN has to reach the VM.
+# ---------------------------------------------------------------------------
+make_code_tarball() {
+  local out="${1:-/tmp/tayavision-code.tar.gz}"
+  tar -czf "$out" -C "$REPO_ROOT" \
+    --exclude='.git' \
+    --exclude='.venv' \
+    --exclude='data' \
+    --exclude='outputs' \
+    --exclude='checkpoints' \
+    --exclude='wandb' \
+    --exclude='.modal' \
+    --exclude='.ruff_cache' \
+    --exclude='.pytest_cache' \
+    --exclude='__pycache__' \
+    --exclude='*.pyc' \
+    --exclude='.inductor_cache' \
+    . 2>/dev/null
+  printf '%s\n' "$out"
+}

--- a/scripts/tpu/deploy_tarball.sh
+++ b/scripts/tpu/deploy_tarball.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# deploy_tarball.sh -- the T2 action: push the working tree to a LIVE slice and
+# relaunch, without recreating the queued resource.
+#
+#   bash scripts/tpu/deploy_tarball.sh
+#   TAYAVISION_ENTRYPOINT=scripts/tpu/tpu_smoke.py bash scripts/tpu/deploy_tarball.sh
+#
+# A redeploy here costs a FULL XLA recompile (~14 min) because the persistent
+# cache has nondeterministic keys on v6e SPMD and never warm-hits. Batch fixes.
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+load_env_file
+resolve_profile
+
+: "${DRY_RUN:=0}"
+: "${SAVE_CKPT_DIR:=}"
+: "${WANDB_RUN_ID:=}"
+
+STAMP="$(date -u +%Y%m%d-%H%M%S)"
+RUN_TAG="${TAYAVISION_RUN_TAG:-deploy-${STAMP}}"
+CODE_URI="${BUCKET}/${CODE_PREFIX}/${STAMP}.tar.gz"
+REMOTE_DIR="/root/expedition-tayavision"
+
+log "deploying to $NODE_ID ($ZONE, $NUM_HOSTS host(s)) tag=$RUN_TAG"
+log "entrypoint=$TAYAVISION_ENTRYPOINT strategy=$TPU_STRATEGY"
+warn_if_cross_region "$ZONE"
+
+# --- mid-run safety ---------------------------------------------------------
+# A deploy kills `train` on every worker. Without durable checkpoints + resume
+# that silently discards progress.
+if [ -z "$SAVE_CKPT_DIR" ]; then
+  log "WARNING: SAVE_CKPT_DIR unset -- this deploy DISCARDS in-flight progress,"
+  log "         and qr_watch.sh will refuse to auto-recycle on the next preemption."
+elif [ "${SAVE_CKPT_DIR#gs://}" = "$SAVE_CKPT_DIR" ]; then
+  log "WARNING: SAVE_CKPT_DIR is not a gs:// URI ($SAVE_CKPT_DIR)."
+  log "         Node-local checkpoints do not survive a recycle. See SPEC.md section 5."
+fi
+if [ -n "$SAVE_CKPT_DIR" ] && [ -z "$WANDB_RUN_ID" ]; then
+  log "NOTE: WANDB_RUN_ID unset -- a resumed run will fork a second W&B entry"
+  log "      instead of rejoining."
+fi
+
+if [ "$DRY_RUN" = "1" ]; then
+  log "DRY_RUN -- would tar, upload to $CODE_URI, and relaunch on --worker=all"
+  exit 0
+fi
+
+# --- 1. tar + upload (including the gitignored .env) ------------------------
+log "1/3 tarring + uploading -> $CODE_URI"
+TARBALL="$(make_code_tarball)"
+gcloud storage cp "$TARBALL" "$CODE_URI" --project="$PROJECT_ID"
+gcloud storage cp "$CODE_URI" "${BUCKET}/${CODE_PREFIX}/latest.tar.gz" --project="$PROJECT_ID"
+rm -f "$TARBALL"
+
+# --- 2. build the remote script locally, scp it -----------------------------
+# Generated as a file rather than inlined so there is exactly ONE level of shell
+# quoting to reason about.
+REMOTE_SH=/tmp/tayavision_remote_deploy.sh
+cat > "$REMOTE_SH" <<REMOTE
+#!/usr/bin/env bash
+set -uo pipefail
+export PATH="/root/.local/bin:\$PATH"
+UV_BIN=/root/.local/bin/uv
+
+mkdir -p "$REMOTE_DIR"
+gcloud storage cp "$CODE_URI" /tmp/code.tar.gz || { echo "code tarball not found"; exit 1; }
+tar -xzf /tmp/code.tar.gz -C "$REMOTE_DIR"
+cd "$REMOTE_DIR"
+# See startup_script.sh step 4: torch_xla is not in pyproject; the named CUDA
+# index is redirected to CPU wheels and torch_xla is layered on top.
+# CPython 3.12 exactly -- pyproject floors at 3.12, libtpu 0.0.21 ceilings at cp312.
+export UV_PYTHON=3.12
+UV_INDEX="pytorch-cu124=https://download.pytorch.org/whl/cpu" \\
+UV_INDEX_STRATEGY=unsafe-best-match "\$UV_BIN" sync || exit 1
+# torch_xla <= 2.7 has no cp312/cp313 wheels; 2.8+ does. torchvision is ABI-locked
+# to torch and must move in lockstep (2.9 -> 0.24). See startup_script.sh step 4.
+"\$UV_BIN" pip install \\
+  --extra-index-url https://download.pytorch.org/whl/cpu \\
+  --extra-index-url https://storage.googleapis.com/libtpu-releases/index.html \\
+  --index-strategy unsafe-best-match \\
+  "torch==${TORCH_VERSION:-2.9.*}" \\
+  "torchvision==${TORCHVISION_VERSION:-0.24.*}" \\
+  "torch_xla[tpu]==${TORCH_XLA_VERSION:-2.9.*}" || exit 1
+"\$UV_BIN" run --no-sync python -c "
+import torch, torchvision
+torch.ops.torchvision.nms
+print(f'torch {torch.__version__} / torchvision {torchvision.__version__} ABI ok')" || exit 1
+
+LIBPYTHON_DIR="\$(find /root/.local/share/uv/python -name 'libpython3.12.so.1.0' -printf '%h\n' 2>/dev/null | head -1)"
+[ -n "\$LIBPYTHON_DIR" ] && export LD_LIBRARY_PATH="\${LIBPYTHON_DIR}:\${LD_LIBRARY_PATH:-}"
+
+export TAYAVISION_ENTRYPOINT="$TAYAVISION_ENTRYPOINT"
+export TAYAVISION_HYDRA_OVERRIDES="$TAYAVISION_HYDRA_OVERRIDES"
+export TAYAVISION_RESUME="${TAYAVISION_RESUME:-off}"
+export TAYAVISION_RUN_TAG="$RUN_TAG"
+export TPU_STRATEGY="$TPU_STRATEGY"
+export SAVE_CKPT_DIR="$SAVE_CKPT_DIR"
+[ -n "$WANDB_RUN_ID" ] && export WANDB_RUN_ID="$WANDB_RUN_ID"
+
+tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+tmux new-session -d -s "$TMUX_SESSION" \\
+  "bash $REMOTE_DIR/scripts/tpu/train_launcher.sh 2>&1 | tee -a /tmp/train.log"
+echo "relaunched tmux $TMUX_SESSION tag=$RUN_TAG"
+REMOTE
+
+log "2/3 scp remote script to all workers"
+gcloud compute tpus tpu-vm scp "$REMOTE_SH" "${NODE_ID}:/tmp/_deploy.sh" \
+  --zone="$ZONE" --project="$PROJECT_ID" --worker=all --quiet
+
+log "3/3 running on --worker=all"
+gcloud compute tpus tpu-vm ssh "$NODE_ID" \
+  --zone="$ZONE" --project="$PROJECT_ID" --worker=all --quiet \
+  --command="sudo bash /tmp/_deploy.sh"
+
+rm -f "$REMOTE_SH"
+notify "deployed tag=$RUN_TAG to $NUM_HOSTS worker(s)" "tayavision"
+log "done. Expect no step line for up to 20 min -- that is XLA compiling, not a hang."
+log "Watch: bash scripts/tpu/ops.sh tail-logs"

--- a/scripts/tpu/launch_qr.sh
+++ b/scripts/tpu/launch_qr.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# launch_qr.sh -- create the Queued Resource that provisions a slice and runs
+# startup_script.sh on every host.
+#
+# Normally invoked via launch_spot.sh (TRC v6e/v5e is spot-only). Direct use is
+# for the on-demand v4 quota.
+#
+#   ZONE=... ACCEL_TYPE=... bash scripts/tpu/launch_qr.sh
+#   DRY_RUN=1 TRC_PROFILE=v6e-8-eu bash scripts/tpu/launch_qr.sh
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+load_env_file
+resolve_profile
+
+: "${SPOT:=0}"
+: "${DRY_RUN:=0}"
+: "${WANDB_RUN_NAME:=}"
+: "${SAVE_CKPT_DIR:=}"
+
+STAMP="$(date -u +%Y%m%d-%H%M%S)"
+CODE_URI="${BUCKET}/${CODE_PREFIX}/${STAMP}.tar.gz"
+LATEST_URI="${BUCKET}/${CODE_PREFIX}/latest.tar.gz"
+
+log "profile=$TRC_PROFILE accel=$ACCEL_TYPE zone=$ZONE hosts=$NUM_HOSTS"
+log "node=$NODE_ID qr=$QR_NAME runtime=$RUNTIME spot=$SPOT"
+log "entrypoint=$TAYAVISION_ENTRYPOINT strategy=$TPU_STRATEGY"
+warn_if_cross_region "$ZONE"
+
+if [ "$NUM_HOSTS" -gt 1 ]; then
+  log ""
+  log "NOTE: $NUM_HOSTS-host slice -- needs $NUM_HOSTS external IPs and a PJRT rendezvous"
+  log "      across every host. Check regional IN_USE_ADDRESSES headroom first:"
+  log "      gcloud compute regions describe \${ZONE%-*} --format='value(quotas)'"
+  log "      A sibling project hit a cap of 8 here once; europe-west4 measured"
+  log "      16/64 on 2026-07-25, so it is headroom, not a wall. Verify, do not assume."
+fi
+
+if [ -z "${SAVE_CKPT_DIR}" ]; then
+  log ""
+  log "NOTE: SAVE_CKPT_DIR is unset. qr_watch.sh will NOT auto-recycle this slice"
+  log "      on preemption -- recycling without durable checkpoints restarts from"
+  log "      step 0. Set it to a gs:// path for anything long-running."
+fi
+
+# --- upload the code tarball ------------------------------------------------
+if [ "$DRY_RUN" != "1" ]; then
+  log "tarring working tree (including the gitignored .env)"
+  TARBALL="$(make_code_tarball)"
+  log "uploading -> $CODE_URI"
+  gcloud storage cp "$TARBALL" "$CODE_URI" --project="$PROJECT_ID"
+  gcloud storage cp "$CODE_URI" "$LATEST_URI" --project="$PROJECT_ID"
+  rm -f "$TARBALL"
+fi
+
+# --- metadata carried by the QR, so a recycled node self-heals --------------
+STARTUP="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/startup_script.sh"
+META="startup-script=${STARTUP}"
+META="${META},tayavision-code-uri=${CODE_URI}"
+META="${META},tayavision-entrypoint=${TAYAVISION_ENTRYPOINT}"
+META="${META},tayavision-hydra-overrides=${TAYAVISION_HYDRA_OVERRIDES}"
+# `auto` here, not off: this metadata is replayed verbatim by every recycle, so
+# the overrides cannot drift and resuming the previous run is exactly the
+# self-heal SPEC.md section 5 describes.
+META="${META},tayavision-resume=${TAYAVISION_RESUME:-auto}"
+META="${META},tayavision-tpu-strategy=${TPU_STRATEGY}"
+META="${META},tayavision-save-ckpt-dir=${SAVE_CKPT_DIR}"
+META="${META},tayavision-wandb-run-name=${WANDB_RUN_NAME}"
+
+CMD=(gcloud compute tpus queued-resources create "$QR_NAME"
+     --node-id="$NODE_ID"
+     --project="$PROJECT_ID"
+     --zone="$ZONE"
+     --accelerator-type="$ACCEL_TYPE"
+     --runtime-version="$RUNTIME"
+     --metadata-from-file=startup-script="$STARTUP"
+     --metadata="${META#startup-script=${STARTUP},}")
+[ "$SPOT" = "1" ] && CMD+=(--spot)
+
+if [ "$DRY_RUN" = "1" ]; then
+  log "DRY_RUN -- would run:"
+  printf '  %q ' "${CMD[@]}"; echo
+  exit 0
+fi
+
+log "creating queued resource"
+"${CMD[@]}"
+
+notify "QR submitted: $QR_NAME ($TRC_PROFILE, $ZONE)" "tayavision"
+log "submitted. Watch with: bash scripts/tpu/ops.sh status"
+log "Keep it alive with:   tmux new -d -s qrwatch-tayavision 'bash scripts/tpu/qr_watch.sh'"

--- a/scripts/tpu/launch_spot.sh
+++ b/scripts/tpu/launch_spot.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# launch_spot.sh -- TRC_PROFILE wrapper around launch_qr.sh with SPOT=1 pinned.
+#
+# TRC v6e and v5e capacity is spot-only, so this is the normal entry point.
+#
+#   TRC_PROFILE=v6e-8-eu bash scripts/tpu/launch_spot.sh
+#   DRY_RUN=1 TRC_PROFILE=v6e-64-ue1d bash scripts/tpu/launch_spot.sh
+#
+# Profiles (authoritative table: docs/tpu/tpu-trc-allocation.md):
+#
+#   v6e-8-eu      v6e-8         europe-west4-a   1 host   co-located   <- DEFAULT
+#   v6e-64-ew4a   v6e-64        europe-west4-a   8 hosts  co-located
+#   v5e-64-ew4b   v5litepod-64  europe-west4-b  16 hosts  co-located
+#   v6e-64-ue1d   v6e-64        us-east1-d       8 hosts  CROSS-REGION
+#   v5e-64-uc1a   v5litepod-64  us-central1-a   16 hosts  CROSS-REGION
+#   v4-32-uc2b    v4-32         us-central2-b    4 hosts  CROSS-REGION
+#
+# One bucket, gs://tayavision-eu. The three CROSS-REGION profiles still work;
+# they pay egress on every checkpoint write. This script warns, it does not
+# block -- see docs/tpu/tpu-capacity-log.md 1 for when that is the right call.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/_lib.sh"
+load_env_file
+
+if ! profile_spec "$TRC_PROFILE" >/dev/null; then
+  log "ERROR: unknown TRC_PROFILE '$TRC_PROFILE'"
+  log "Valid: v6e-8-eu v6e-64-ew4a v5e-64-ew4b v6e-64-ue1d v5e-64-uc1a v4-32-uc2b"
+  exit 1
+fi
+
+export SPOT=1
+exec bash "$HERE/launch_qr.sh"

--- a/scripts/tpu/ops.sh
+++ b/scripts/tpu/ops.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# ops.sh -- daily operations against the current slice.
+#
+#   bash scripts/tpu/ops.sh preflight    # check before spending capacity
+#   bash scripts/tpu/ops.sh status       # QR + node state
+#   bash scripts/tpu/ops.sh tail-logs    # follow /tmp/train.log on worker 0
+#   bash scripts/tpu/ops.sh attach       # tmux attach on worker 0
+#   bash scripts/tpu/ops.sh ssh          # shell on worker 0
+#   bash scripts/tpu/ops.sh delete       # tear down the QR (stops billing)
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/_lib.sh"
+load_env_file
+resolve_profile
+
+CMD="${1:-status}"
+
+case "$CMD" in
+
+  preflight)
+    rc=0
+    echo "== preflight: $TRC_PROFILE ($ACCEL_TYPE, $ZONE, $NUM_HOSTS host(s)) =="
+    echo
+
+    echo "-- gcloud --"
+    acct="$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null | head -1)"
+    if [ -n "$acct" ]; then echo "   authed: $acct"; else echo "   NOT AUTHED  <- gcloud auth login"; rc=1; fi
+    proj="$(gcloud config get-value project 2>/dev/null)"
+    echo "   project: ${proj:-<unset>} (scripts use $PROJECT_ID)"
+
+    echo
+    echo "-- .env (presence only, never values) --"
+    if [ -f "$REPO_ROOT/.env" ]; then
+      for k in HF_TOKEN WANDB_API_KEY NTFY_TOPIC WANDB_PROJECT WANDB_ENTITY PROJECT_ID; do
+        # `KEY=` with an empty value must NOT report as set. A key that is
+        # present-but-blank is the worst case: it looks configured and behaves
+        # as absent. That shape already cost a sibling project a day of silently
+        # dropped alerts.
+        val="$(sed -n "s/^${k}=//p" "$REPO_ROOT/.env" 2>/dev/null | head -1 | tr -d '"'"'"' \t\r')"
+        if [ -n "$val" ]; then
+          case "$k" in
+            WANDB_PROJECT|WANDB_ENTITY|PROJECT_ID) echo "   $k: $val" ;;
+            *)                                     echo "   $k: set" ;;
+          esac
+        else
+          case "$k" in
+            HF_TOKEN)
+              echo "   $k: MISSING/EMPTY  <- FATAL: CohereLabs/tiny-aya-* is a GATED repo"; rc=1 ;;
+            WANDB_API_KEY)
+              echo "   $k: missing/empty  (run trains but is unobservable)" ;;
+            NTFY_TOPIC)
+              echo "   $k: missing/empty  (notify() is a silent no-op: fine for a"
+              echo "                       foreground smoke, NOT for an overnight run)" ;;
+            WANDB_PROJECT)
+              echo "   $k: missing/empty  (Hydra runs fall back to config/config.yaml,"
+              echo "                       which names a GPU results project)" ;;
+            WANDB_ENTITY)
+              echo "   $k: missing/empty  (wandb picks your default entity)" ;;
+            PROJECT_ID)
+              echo "   $k: missing/empty  (defaults to $PROJECT_ID)" ;;
+          esac
+        fi
+      done
+    else
+      echo "   NO .env AT REPO ROOT  <- cp .env.example .env, then fill HF_TOKEN"
+      echo "   The tarball ships .env to the VM; there is no git clone in this flow."
+      rc=1
+    fi
+
+    echo
+    echo "-- entrypoint --"
+    if [ -f "$REPO_ROOT/$TAYAVISION_ENTRYPOINT" ]; then
+      echo "   $TAYAVISION_ENTRYPOINT: exists"
+      case "$TAYAVISION_ENTRYPOINT" in
+        pipeline/train_*)
+          echo "   WARNING: pipeline/train_*.py is DDP + CUDA and does NOT run on TPU."
+          echo "            See .claude/orchestration/SPEC.md section 9."
+          rc=1 ;;
+      esac
+    else
+      echo "   $TAYAVISION_ENTRYPOINT: MISSING"; rc=1
+    fi
+
+    echo
+    echo "-- checkpoints --"
+    if [ -z "${SAVE_CKPT_DIR:-}" ]; then
+      echo "   SAVE_CKPT_DIR unset -- qr_watch will NOT auto-recycle on preemption"
+    elif [ "${SAVE_CKPT_DIR#gs://}" != "$SAVE_CKPT_DIR" ]; then
+      echo "   $SAVE_CKPT_DIR (durable, auto-recycle enabled)"
+    else
+      echo "   $SAVE_CKPT_DIR is NOT gs:// -- auto-recycle disabled"
+    fi
+
+    echo
+    echo "-- bucket --"
+    if gcloud storage ls "$BUCKET" >/dev/null 2>&1; then
+      echo "   $BUCKET: reachable"
+    else
+      echo "   $BUCKET: NOT REACHABLE  <- bash scripts/tpu/setup_gcp.sh"; rc=1
+    fi
+    warn_if_cross_region "$ZONE"
+
+    echo
+    [ "$rc" -eq 0 ] && echo "preflight OK" || echo "preflight FAILED -- fix the above before launching"
+    exit "$rc"
+    ;;
+
+  status)
+    echo "== queued resource: $QR_NAME ($ZONE) =="
+    gcloud compute tpus queued-resources describe "$QR_NAME" \
+      --zone="$ZONE" --project="$PROJECT_ID" \
+      --format='table(name.basename(),state.state)' 2>/dev/null \
+      || echo "  (no QR named $QR_NAME)"
+    echo
+    echo "== all queued resources in $ZONE =="
+    echo "   (SUSPENDED/FAILED husks still book quota -- delete them)"
+    gcloud compute tpus queued-resources list \
+      --zone="$ZONE" --project="$PROJECT_ID" \
+      --format='table(name.basename(),state.state)' 2>/dev/null || true
+    echo
+    echo "== node: $NODE_ID =="
+    gcloud compute tpus tpu-vm describe "$NODE_ID" \
+      --zone="$ZONE" --project="$PROJECT_ID" \
+      --format='table(name.basename(),state,health)' 2>/dev/null \
+      || echo "  (no node named $NODE_ID)"
+    ;;
+
+  stage-logs)
+    gcloud compute tpus tpu-vm ssh "$NODE_ID" \
+      --zone="$ZONE" --project="$PROJECT_ID" --worker=0 --quiet \
+      --command="sudo tail -n 25 /tmp/stage_data.log 2>/dev/null || echo '(no staging log yet)'; \
+                 echo '--- marker ---'; \
+                 sudo ls -la ${TAYAVISION_DATA_DIR:-/root/data/llava-pretrain}/.staged 2>/dev/null \
+                   || echo 'not yet staged'"
+    ;;
+
+  tail-logs)
+    # tail, never head: a head -N over repeating step lines pushes the exit
+    # marker out of range. Diagnoser row 25.
+    gcloud compute tpus tpu-vm ssh "$NODE_ID" \
+      --zone="$ZONE" --project="$PROJECT_ID" --worker=0 --quiet \
+      --command="tail -f -n 60 /tmp/train.log"
+    ;;
+
+  attach)
+    echo "tmux session '$TMUX_SESSION' is root-owned; using sudo."
+    gcloud compute tpus tpu-vm ssh "$NODE_ID" \
+      --zone="$ZONE" --project="$PROJECT_ID" --worker=0 \
+      -- -t "sudo tmux attach -t $TMUX_SESSION"
+    ;;
+
+  ssh)
+    gcloud compute tpus tpu-vm ssh "$NODE_ID" \
+      --zone="$ZONE" --project="$PROJECT_ID" --worker=0
+    ;;
+
+  delete)
+    echo "This deletes QR '$QR_NAME' in $ZONE and stops billing."
+    read -r -p "Type the profile name ($TRC_PROFILE) to confirm: " confirm
+    if [ "$confirm" != "$TRC_PROFILE" ]; then echo "aborted"; exit 1; fi
+    # --force is REQUIRED for the normal case. An ACTIVE queued resource owns a
+    # node, and without --force the API rejects the delete outright:
+    #   code 9: DeleteQueuedResource is not supported when state is ACTIVE
+    #           (must be one of [ACCEPTED WAITING_FOR_RESOURCES SUSPENDED FAILED])
+    # i.e. the un-forced form only ever worked on husks -- never on a slice you
+    # had actually finished using, which is the only time you run this.
+    gcloud compute tpus queued-resources delete "$QR_NAME" \
+      --zone="$ZONE" --project="$PROJECT_ID" --force --quiet
+    notify "QR deleted: $QR_NAME" "tayavision"
+    ;;
+
+  *)
+    echo "usage: bash scripts/tpu/ops.sh {preflight|status|stage-logs|tail-logs|attach|ssh|delete}"
+    exit 1
+    ;;
+esac

--- a/scripts/tpu/qr_watch.sh
+++ b/scripts/tpu/qr_watch.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# qr_watch.sh -- the QR babysitter (tier T3).
+#
+# Runs on the WORKSTATION, in detached tmux:
+#   tmux new -d -s qrwatch-tayavision 'bash scripts/tpu/qr_watch.sh'
+#
+# The session name is suffixed on purpose: this workstation also runs a plain
+# `qrwatch` for llm-architectures, and `tmux new -s qrwatch` against an existing
+# session attaches to the wrong one, leaving this project's QR unwatched.
+#
+# Polls the queued resource; on SUSPENDING/SUSPENDED/FAILED it captures
+# forensics, checks for a quota-class abort, CHECKS CHECKPOINT DURABILITY,
+# deletes the QR, and resubmits the identical launch env.
+#
+# ONE RESUBMITTER PER QR, EVER. If the QR is absent this exits rather than
+# racing a human who is mid-recreate -- two resubmitters produce duplicate nodes
+# and split-brain rendezvous.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/_lib.sh"
+load_env_file
+resolve_profile
+
+LOG=/tmp/qr_watch_tayavision.log
+exec > >(tee -a "$LOG") 2>&1
+
+: "${SAVE_CKPT_DIR:=}"
+
+resubmits=0
+last_state=""
+last_heartbeat=$(date +%s)
+
+log "qr_watch start: qr=$QR_NAME zone=$ZONE profile=$TRC_PROFILE"
+log "  budget=$MAX_RESUBMITS poll=${POLL_SECONDS}s cooldown=${COOLDOWN_SECONDS}s"
+
+# --- the durability gate ----------------------------------------------------
+# This is the divergence from BOTH source repos. tinyaya never auto-recycled;
+# llm-architectures always did. Here: only when checkpoints survive the node.
+#
+# Recycling with node-local checkpoints restarts from step 0 AND re-pays ~14 min
+# of cold-boot XLA compile, up to 20 times, silently. That is not self-healing,
+# it is a capacity incinerator.
+DURABLE=0
+if [ -n "$SAVE_CKPT_DIR" ] && [ "${SAVE_CKPT_DIR#gs://}" != "$SAVE_CKPT_DIR" ]; then
+  DURABLE=1
+  log "  checkpoints: $SAVE_CKPT_DIR (durable) -- auto-recycle ENABLED"
+else
+  log "  checkpoints: ${SAVE_CKPT_DIR:-<unset>} (NOT durable) -- auto-recycle DISABLED"
+  log "  Preemption will be reported, not repaired. Set SAVE_CKPT_DIR to a gs:// path."
+fi
+
+while true; do
+  state="$(gcloud compute tpus queued-resources describe "$QR_NAME" \
+            --zone="$ZONE" --project="$PROJECT_ID" \
+            --format='value(state.state)' 2>/dev/null || echo MISSING)"
+
+  if [ "$state" != "$last_state" ]; then
+    log "QR state: ${last_state:-<start>} -> $state"
+    [ -n "$last_state" ] && notify "QR state changed: $last_state -> $state" "tayavision"
+    last_state="$state"
+  fi
+
+  case "$state" in
+    MISSING)
+      log "QR is absent. Exiting rather than racing a human mid-recreate."
+      notify "qr_watch exiting: QR $QR_NAME is absent" "tayavision"
+      exit 0
+      ;;
+
+    SUSPENDING|SUSPENDED|FAILED)
+      log "QR in terminal state $state -- capturing forensics"
+      forensics="/tmp/qr_forensics_${QR_NAME}_$(date -u +%Y%m%d-%H%M%S).json"
+      gcloud compute tpus queued-resources describe "$QR_NAME" \
+        --zone="$ZONE" --project="$PROJECT_ID" --format=json > "$forensics" 2>/dev/null || true
+      log "  forensics -> $forensics"
+
+      # quota-class abort: resubmitting into a wall cannot succeed
+      if grep -qiE 'quota|IN_USE_ADDRESSES|exhausted|PerProjectPerZone' "$forensics" 2>/dev/null; then
+        log "QUOTA-CLASS FAILURE -- resubmitting cannot help. Stopping."
+        log "  On this grant the usual wall is IN_USE_ADDRESSES (regional cap 8),"
+        log "  not TPU chips. See docs/tpu/tpu-capacity-log.md 7.1."
+        notify "quota abort on $QR_NAME -- needs a human" "tayavision STOPPED"
+        exit 1
+      fi
+
+      if [ "$DURABLE" -ne 1 ]; then
+        log "RECYCLE BLOCKED: SAVE_CKPT_DIR is not a gs:// URI."
+        log "  Recycling would restart from step 0 and re-pay ~14 min of compile."
+        notify "recycle BLOCKED — SAVE_CKPT_DIR not gs:// — $QR_NAME preempted, progress lost" \
+               "tayavision STOPPED"
+        exit 1
+      fi
+
+      if [ "$resubmits" -ge "$MAX_RESUBMITS" ]; then
+        log "budget exhausted ($resubmits/$MAX_RESUBMITS). Stopping."
+        notify "budget exhausted ($MAX_RESUBMITS) on $QR_NAME" "tayavision STOPPED"
+        exit 1
+      fi
+
+      log "deleting dead QR"
+      gcloud compute tpus queued-resources delete "$QR_NAME" \
+        --zone="$ZONE" --project="$PROJECT_ID" --quiet >/dev/null 2>&1 || true
+
+      sleep "$COOLDOWN_SECONDS"
+
+      resubmits=$((resubmits + 1))
+      log "resubmitting ($resubmits/$MAX_RESUBMITS)"
+      if bash "$HERE/launch_spot.sh"; then
+        notify "resubmitted ($resubmits/$MAX_RESUBMITS): $QR_NAME" "tayavision"
+        last_state=""
+      else
+        log "resubmit failed"
+        notify "resubmit FAILED ($resubmits/$MAX_RESUBMITS): $QR_NAME" "tayavision STOPPED"
+        exit 1
+      fi
+      ;;
+  esac
+
+  # heartbeat -- a silent watcher is indistinguishable from a dead one
+  now=$(date +%s)
+  if [ $((now - last_heartbeat)) -ge "$HEARTBEAT_SECONDS" ]; then
+    notify "heartbeat: $QR_NAME is $state, $resubmits/$MAX_RESUBMITS resubmits used" "tayavision"
+    last_heartbeat=$now
+  fi
+
+  sleep "$POLL_SECONDS"
+done

--- a/scripts/tpu/setup_gcp.sh
+++ b/scripts/tpu/setup_gcp.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# setup_gcp.sh -- one-time GCP bootstrap for Tiny Aya Vision TPU work.
+#
+# Enables the APIs, creates the ONE bucket, and grants the TPU service identity
+# access to it. Idempotent: safe to re-run.
+#
+#   bash scripts/tpu/setup_gcp.sh
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+load_env_file
+
+BUCKET_LOCATION="${BUCKET_LOCATION:-europe-west4}"
+
+log "project=$PROJECT_ID bucket=$BUCKET location=$BUCKET_LOCATION"
+log ""
+log "Tiny Aya Vision uses ONE bucket. Only the three europe-west4-* profiles are"
+log "co-located with it; anything else pays egress. See"
+log "docs/tpu/tpu-trc-allocation.md 'Bucket co-location'."
+log ""
+
+log "1/3 enabling APIs (tpu, storage, compute)"
+gcloud services enable \
+  tpu.googleapis.com \
+  storage.googleapis.com \
+  compute.googleapis.com \
+  --project="$PROJECT_ID"
+
+log "2/3 creating $BUCKET in $BUCKET_LOCATION (if absent)"
+if gcloud storage buckets describe "$BUCKET" --project="$PROJECT_ID" >/dev/null 2>&1; then
+  log "    already exists"
+else
+  gcloud storage buckets create "$BUCKET" \
+    --project="$PROJECT_ID" \
+    --location="$BUCKET_LOCATION" \
+    --uniform-bucket-level-access
+  log "    created"
+fi
+
+log "3/3 granting objectAdmin to the TPU service identity"
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+TPU_SA="service-${PROJECT_NUMBER}@cloud-tpu.iam.gserviceaccount.com"
+COMPUTE_SA="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+
+for sa in "$TPU_SA" "$COMPUTE_SA"; do
+  gcloud storage buckets add-iam-policy-binding "$BUCKET" \
+    --member="serviceAccount:${sa}" \
+    --role=roles/storage.objectAdmin \
+    --project="$PROJECT_ID" >/dev/null
+  log "    granted: $sa"
+done
+
+log ""
+log "done. Next:"
+log "  cp .env.example .env    # then fill HF_TOKEN -- the model repos are GATED"
+log "  bash scripts/tpu/ops.sh preflight"
+log "  TRC_PROFILE=v6e-8-eu bash scripts/tpu/launch_spot.sh"

--- a/scripts/tpu/stage_data.sh
+++ b/scripts/tpu/stage_data.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# stage_data.sh -- download and extract a training corpus ON the TPU VM.
+#
+#   bash scripts/tpu/stage_data.sh                 # from the workstation, fans out
+#   bash scripts/tpu/stage_data.sh --local         # ON a worker, does the work
+#
+# Runs detached in tmux `stage` on each worker. That is not decoration: a
+# ~13 GB download takes long enough that a workstation `gcloud ssh` will be
+# interrupted, and a killed ssh client does NOT kill the remote command -- it
+# orphans it. Detached + a marker file means an interrupted invocation is
+# resumable rather than corrupt.
+#
+# Idempotent: a completed stage writes `.staged`, and re-running is a no-op.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# --local: the worker-side half.
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--local" ]; then
+  DATA_DIR="${TAYAVISION_DATA_DIR:-/root/data/llava-pretrain}"
+  REPO_DIR="${REPO_DIR:-/root/expedition-tayavision}"
+  MARKER="$DATA_DIR/.staged"
+
+  exec > >(tee -a /tmp/stage_data.log) 2>&1
+  echo "[$(date -Is)] stage_data begin -> $DATA_DIR"
+
+  if [ -f "$MARKER" ]; then
+    echo "[$(date -Is)] already staged (marker present); nothing to do"
+    exit 0
+  fi
+
+  # ~13 GB zip + ~13 GB extracted at peak. Refuse early rather than filling the
+  # root disk and taking the training process down with it.
+  avail_gb=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+  if [ "${avail_gb:-0}" -lt 35 ]; then
+    echo "[$(date -Is)] FATAL: only ${avail_gb}G free on /, need ~35G peak"
+    exit 1
+  fi
+  echo "[$(date -Is)] ${avail_gb}G free, proceeding"
+
+  mkdir -p "$DATA_DIR"
+  cd "$REPO_DIR" || exit 1
+
+  export PATH="/root/.local/bin:$PATH"
+  # HF_TOKEN comes from the tarball's .env. LLaVA-Pretrain is public, but the
+  # same loader is used for gated corpora, so keep the env consistent.
+  set -a; [ -f "$REPO_DIR/.env" ] && . "$REPO_DIR/.env"; set +a
+
+  # Validate against the contract the DATASET uses, not against a guessed
+  # layout. `AlignmentDataset.__getitem__` does `self.data_dir / item["image"]`,
+  # and the JSON's image field is shard-relative ("00207/002078413.jpg"), so the
+  # zip's shard dirs land directly under DATA_DIR. There is no `images/`
+  # subdirectory, despite what download_llava_pretrain.py prints.
+  validate() {
+    local json="$DATA_DIR/blip_laion_cc_sbu_558k.json"
+    [ -s "$json" ] || { echo "  no JSON at $json"; return 1; }
+    local first
+    first=$(/root/.local/bin/uv run --no-sync python -c "
+import json,sys
+d=json.load(open('$json'))
+print(d[0]['image'] if d and 'image' in d[0] else '')" 2>/dev/null)
+    [ -n "$first" ] || { echo "  JSON has no image field"; return 1; }
+    [ -f "$DATA_DIR/$first" ] || { echo "  first image missing: $DATA_DIR/$first"; return 1; }
+    local n
+    n=$(find "$DATA_DIR" -name '*.jpg' -type f 2>/dev/null | head -20000 | wc -l)
+    [ "$n" -ge 10000 ] || { echo "  only $n jpgs found"; return 1; }
+    echo "  ok: JSON + $first resolves + ${n}+ jpgs"
+    return 0
+  }
+
+  # Check BEFORE downloading. download_llava_pretrain.py guards on an
+  # `images/` dir that this layout never creates, so an unguarded rerun would
+  # happily re-fetch 13 GB over a corpus that is already complete.
+  echo "[$(date -Is)] checking for an existing corpus..."
+  if validate; then
+    echo "[$(date -Is)] corpus already present; skipping download"
+  else
+    echo "[$(date -Is)] not present, downloading"
+    /root/.local/bin/uv run --no-sync python scripts/download_llava_pretrain.py \
+      --output-dir "$DATA_DIR" || {
+      echo "[$(date -Is)] download failed"
+      exit 1
+    }
+    if ! validate; then
+      echo "[$(date -Is)] FATAL: corpus still invalid after download"
+      exit 1
+    fi
+  fi
+
+  date -Is > "$MARKER"
+  # `n_img` used to be set by the old inline check; validate() owns counting now.
+  # Under `set -u` the stale reference aborted the script AFTER the marker was
+  # written, so it looked like success with an error printed underneath.
+  echo "[$(date -Is)] staged: $(du -sh "$DATA_DIR" | cut -f1)"
+  echo "[$(date -Is)] stage_data complete"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Workstation side: fan out, detached.
+# ---------------------------------------------------------------------------
+source "$HERE/_lib.sh"
+load_env_file
+resolve_profile
+
+: "${TAYAVISION_DATA_DIR:=/root/data/llava-pretrain}"
+
+log "staging data on $NODE_ID ($NUM_HOSTS worker(s)) -> $TAYAVISION_DATA_DIR"
+log "  ~13 GB per worker; runs detached in tmux 'stage'"
+log "  follow with: ops.sh stage-logs"
+
+gcloud compute tpus tpu-vm ssh "$NODE_ID" \
+  --zone="$ZONE" --project="$PROJECT_ID" --worker=all --quiet \
+  --command="sudo tmux kill-session -t stage 2>/dev/null; \
+             sudo tmux new-session -d -s stage \
+             'TAYAVISION_DATA_DIR=$TAYAVISION_DATA_DIR bash /root/expedition-tayavision/scripts/tpu/stage_data.sh --local'; \
+             echo launched"
+
+notify "data staging started on $NODE_ID" "tayavision"
+log "launched. This takes a while; poll with:"
+log "  bash scripts/tpu/ops.sh stage-logs"

--- a/scripts/tpu/startup_script.sh
+++ b/scripts/tpu/startup_script.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# startup_script.sh -- runs as root on EVERY TPU host, on EVERY boot.
+#
+# Must be idempotent: a spot preemption reboots the host and re-runs this.
+#
+# Reads its knobs from GCE metadata, which is what makes boot self-heal work --
+# a recycled node re-fetches the same code, the same entrypoint, and the same
+# W&B identity with no human action.
+set -uo pipefail
+
+exec > >(tee -a /tmp/startup.log) 2>&1
+echo "[$(date -Is)] startup_script.sh begin"
+
+md() {
+  curl -fsS -H 'Metadata-Flavor: Google' \
+    "http://metadata.google.internal/computeMetadata/v1/instance/attributes/$1" 2>/dev/null || true
+}
+
+CODE_URI="$(md tayavision-code-uri)"
+ENTRYPOINT="$(md tayavision-entrypoint)"
+HYDRA_OVERRIDES="$(md tayavision-hydra-overrides)"
+RESUME="$(md tayavision-resume)"
+STRATEGY="$(md tayavision-tpu-strategy)"
+SAVE_CKPT_DIR="$(md tayavision-save-ckpt-dir)"
+WANDB_RUN_NAME="$(md tayavision-wandb-run-name)"
+
+REPO_DIR="${REPO_DIR:-/root/expedition-tayavision}"
+TMUX_SESSION="${TMUX_SESSION:-train}"
+
+echo "[$(date -Is)] code=$CODE_URI entrypoint=$ENTRYPOINT strategy=$STRATEGY"
+
+# --- 1. apt, with a retry loop --------------------------------------------
+# Two workers out of sixteen used to miss the PJRT rendezvous because dpkg was
+# locked at boot by unattended-upgrades. Diagnoser row 4.
+for i in $(seq 1 30); do
+  if apt-get update -qq >/dev/null 2>&1 && \
+     apt-get install -y -qq tmux curl tar >/dev/null 2>&1; then
+    echo "[$(date -Is)] apt ok (attempt $i)"
+    break
+  fi
+  echo "[$(date -Is)] apt locked, retry $i/30"
+  sleep 10
+done
+
+# --- 2. uv -----------------------------------------------------------------
+# `which uv` is empty under sudo; always use the absolute path in root contexts.
+UV_BIN=/root/.local/bin/uv
+if [ ! -x "$UV_BIN" ]; then
+  echo "[$(date -Is)] installing uv"
+  curl -fsSL https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 || true
+fi
+export PATH="/root/.local/bin:$PATH"
+
+# --- 3. code, from the GCS tarball. NEVER a git clone ----------------------
+# The tarball carries the gitignored .env, and .env carries HF_TOKEN. The model
+# repos (CohereLabs/tiny-aya-*) are GATED: without it the run cannot start.
+if [ -n "$CODE_URI" ]; then
+  echo "[$(date -Is)] fetching $CODE_URI"
+  mkdir -p "$REPO_DIR"
+  if gcloud storage cp "$CODE_URI" /tmp/code.tar.gz 2>/dev/null; then
+    tar -xzf /tmp/code.tar.gz -C "$REPO_DIR"
+    echo "[$(date -Is)] code extracted to $REPO_DIR"
+  else
+    echo "[$(date -Is)] ERROR: code tarball not found: $CODE_URI"
+    exit 1
+  fi
+else
+  echo "[$(date -Is)] ERROR: code tarball not found (no tayavision-code-uri metadata)"
+  exit 1
+fi
+
+cd "$REPO_DIR"
+
+# --- 4. deps ---------------------------------------------------------------
+# torch_xla is deliberately NOT in pyproject.toml. pyproject pins torch to the
+# CUDA 12.4 index for all Linux (that is correct for the Modal/GPU path), and a
+# TPU VM needs CPU torch + torch_xla + libtpu instead. Rather than fight that
+# pin -- or fork the lockfile and risk the Modal path -- we redirect the named
+# index at sync time and add torch_xla afterwards. pyproject and uv.lock stay
+# untouched, so the GPU path is bit-identical.
+# Version choice is forced, not preferred. torch_xla <= 2.7 ships only
+# cp39/cp310/cp311 wheels; pyproject's `requires-python = ">=3.12,<3.14"` makes uv
+# pick CPython 3.13, so those versions cannot resolve at all. 2.8.0 is the first
+# release with cp312/cp313. torch is upgraded to match on the VM only -- the
+# lockfile still says 2.6.0 and the Modal path is untouched.
+TORCH_XLA_VERSION="${TORCH_XLA_VERSION:-2.9.*}"
+TORCH_VERSION="${TORCH_VERSION:-2.9.*}"
+# torchvision is ABI-locked to torch and MUST be upgraded in lockstep. The lock
+# installs the 2.6-matched build; leaving it there against torch 2.9 fails with
+# "operator torchvision::nms does not exist", which then surfaces far from its
+# cause as `ModuleNotFoundError: Could not import module 'AutoProcessor'` --
+# transformers' lazy importer swallowing the real error. Pairing: torch 2.6->tv
+# 0.21, 2.7->0.22, 2.8->0.23, 2.9->0.24.
+TORCHVISION_VERSION="${TORCHVISION_VERSION:-0.24.*}"
+LIBTPU_INDEX=https://storage.googleapis.com/libtpu-releases/index.html
+
+# CPython 3.12 EXACTLY, and it is pinned by intersection, not preference:
+#   pyproject requires-python  >= 3.12   -> floor 3.12
+#   libtpu 0.0.21 wheels       <= cp312  -> ceiling 3.12   (torch_xla 2.9 dep)
+# Left to itself uv picks 3.13 (the newest the floor allows) and torch_xla
+# cannot resolve. Do not "modernise" this to 3.13 until libtpu ships cp313.
+export UV_PYTHON="${UV_PYTHON:-3.12}"
+
+# UV_INDEX_STRATEGY is required here, not optional. Overriding a named index via
+# UV_INDEX drops its `explicit = true` flag from pyproject, so the CPU wheel
+# index becomes a GENERAL index. uv's default first-index strategy then refuses
+# to look at PyPI for anything that index also carries, and resolution dies on
+# `requests==2.28.1` (which is all download.pytorch.org publishes).
+# unsafe-best-match lets uv pick the best version across both. The "unsafe" name
+# is about dependency confusion between a private and a public index; here both
+# are public and trusted (pypi.org, download.pytorch.org).
+echo "[$(date -Is)] uv sync (torch redirected to CPU wheels)"
+UV_INDEX="pytorch-cu124=https://download.pytorch.org/whl/cpu" \
+UV_INDEX_STRATEGY=unsafe-best-match \
+  "$UV_BIN" sync || {
+  echo "[$(date -Is)] uv sync failed"
+  exit 1
+}
+
+echo "[$(date -Is)] installing torch==$TORCH_VERSION torchvision==$TORCHVISION_VERSION torch_xla[tpu]==$TORCH_XLA_VERSION"
+"$UV_BIN" pip install \
+  --extra-index-url https://download.pytorch.org/whl/cpu \
+  --extra-index-url "$LIBTPU_INDEX" \
+  --index-strategy unsafe-best-match \
+  "torch==${TORCH_VERSION}" \
+  "torchvision==${TORCHVISION_VERSION}" \
+  "torch_xla[tpu]==${TORCH_XLA_VERSION}" || {
+  echo "[$(date -Is)] torch_xla install failed"
+  exit 1
+}
+# Fail loudly here rather than 200 lines into a traceback somewhere else.
+"$UV_BIN" run --no-sync python -c "
+import torch, torchvision
+torch.ops.torchvision.nms  # the op that is missing on an ABI mismatch
+print(f'torch {torch.__version__} / torchvision {torchvision.__version__} ABI ok')" || {
+  echo "[$(date -Is)] torch/torchvision ABI mismatch"
+  exit 1
+}
+
+# --- 5. the torch_xla / libpython link -------------------------------------
+# torch_xla's _XLAC.so dynamically links libpython3.12.so.1.0, which uv keeps
+# outside the default loader path. Without this every `import torch_xla` fails.
+# Diagnoser row 1. This is the single most likely first-boot failure.
+LIBPYTHON_DIR="$(find /root/.local/share/uv/python -name 'libpython3.12.so.1.0' -printf '%h\n' 2>/dev/null | head -1)"
+if [ -n "$LIBPYTHON_DIR" ]; then
+  export LD_LIBRARY_PATH="${LIBPYTHON_DIR}:${LD_LIBRARY_PATH:-}"
+  echo "[$(date -Is)] LD_LIBRARY_PATH += $LIBPYTHON_DIR"
+else
+  echo "[$(date -Is)] WARNING: libpython3.12.so.1.0 not found; torch_xla import may fail"
+fi
+
+# --- 6. launch in tmux -----------------------------------------------------
+export TAYAVISION_ENTRYPOINT="${ENTRYPOINT:-scripts/tpu/tpu_smoke.py}"
+export TAYAVISION_HYDRA_OVERRIDES="$HYDRA_OVERRIDES"
+export TAYAVISION_RESUME="${RESUME:-auto}"
+export TPU_STRATEGY="${STRATEGY:-replicated}"
+export SAVE_CKPT_DIR="$SAVE_CKPT_DIR"
+export TAYAVISION_RUN_TAG="boot-$(date -u +%Y%m%d-%H%M%S)"
+[ -n "$WANDB_RUN_NAME" ] && export WANDB_RUN_NAME
+
+tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+tmux new-session -d -s "$TMUX_SESSION" \
+  "bash $REPO_DIR/scripts/tpu/train_launcher.sh 2>&1 | tee -a /tmp/train.log"
+
+echo "[$(date -Is)] startup_script.sh complete"

--- a/scripts/tpu/tpu_smoke.py
+++ b/scripts/tpu/tpu_smoke.py
@@ -1,0 +1,355 @@
+"""Control-plane smoke entrypoint — the default TAYAVISION_ENTRYPOINT.
+
+This is NOT training. `pipeline/train_*.py` is DDP + CUDA and does not run under
+torch_xla; see `.claude/orchestration/SPEC.md` section 9.
+
+What it does prove, on real silicon:
+  * torch_xla imports (i.e. the libpython / _XLAC.so link resolved)
+  * chips are visible and a mesh can be built
+  * bf16 tensors of realistic size fit, and what the HBM headroom is
+  * the XLA compile-cause counters behave (flat after warmup)
+  * the log markers every watcher greps for are emitted in the right format
+
+With --load-backbone it additionally downloads and materializes the real model,
+which exercises the gated-HF-repo path (`HF_TOKEN` reaching the VM inside the
+tarball's `.env`) and reports the true memory envelope. Those are the two things
+most likely to be wrong on a first boot.
+
+Deliberately module-level `import torch_xla`: this file lives under `scripts/`,
+outside the trees `scripts/ci/check_backend_seam.sh` guards.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import time
+
+STEPS = 20
+
+
+def hbm_report() -> list[str]:
+    """Per-chip HBM and duty cycle, or an honest explanation of why not.
+
+    `xm.get_memory_info()` defaults to `xla_device()`, which under SPMD is the
+    *virtual* device `SPMD:0`, and `_xla_memory_info` rejects it outright:
+    "MemoryInfo not supported for SPMD virtual device". Passing
+    `torch_xla.devices()` does not help -- under SPMD that returns the same
+    virtual device. Both were tried; both fail.
+
+    Two things that do work, in preference order:
+
+    1. `tpu_info` (installed as a torch_xla dependency) reads libtpu's gRPC
+       metrics server directly. SPMD-agnostic, per-chip, and it also yields
+       duty cycle -- which is what tells a compile apart from a hang
+       (tpu-diagnoser row 15).
+    2. `xm.get_memory_info()` against the *real* runtime device strings from
+       `_xla_get_all_runtime_devices()`, which are not the SPMD virtual device.
+
+    This is the logic `src/backend/base.py::memory_info()` will need when the
+    seam lands (PLAN P6); keep it portable.
+    """
+    def gib(b: int) -> str:
+        return f"{b / 1024**3:.3f} GiB" if b >= 1024**3 else f"{b / 1024**2:.1f} MiB"
+
+    out: list[str] = []
+    total_b = used_b = 0
+    src_total = src_used = "none"
+    detail = ""
+
+    # Source 1: libtpu's gRPC metrics server, via tpu_info.
+    try:
+        from tpu_info import device as tpu_device
+        from tpu_info import metrics as tpu_metrics
+
+        chip_type, count = tpu_device.get_local_chips()
+        if chip_type is not None:
+            usages = tpu_metrics.get_chip_usage(chip_type)
+            total_b = max(u.total_memory for u in usages)
+            src_total = "tpu_info"
+            # 1 MiB floor separates "nothing resident" from a real measurement.
+            # The gauge DOES track program allocations -- it read 8.058 GiB with
+            # the 4.33B model resident (2026-07-25), matching 4.33e9 x 2 bytes
+            # exactly. An earlier reading of ~0 with `--alloc-gib 8` was a flawed
+            # test, not a broken gauge: a `torch.zeros` that no computation
+            # consumes gets dead-code-eliminated by XLA before it is ever
+            # allocated. Loaded weights cannot be elided, which is why they show.
+            u_b = max(u.memory_usage for u in usages)
+            if u_b >= 1024**2:
+                used_b, src_used = u_b, "tpu_info"
+            duty = max(u.duty_cycle_pct for u in usages)
+            detail = (f"{len(usages)} core(s), {count} local chip(s) [{chip_type}]")
+            out.append(f"duty_cycle: max {duty:.1f}% across chips")
+    except Exception as exc:  # noqa: BLE001 - diagnostic only, never fatal
+        out.append(f"note: tpu_info unavailable ({type(exc).__name__}: {exc})")
+
+    # Source 2: XLA's own allocator view, per REAL runtime device. Not a plain
+    # fallback -- it is consulted whenever libtpu reported usage 0, because on
+    # torch_xla 2.9 / libtpu 0.0.21 the MEMORY_USAGE gauge reads 0 even with
+    # 8 GiB pinned on device (verified 2026-07-25), while TOTAL_MEMORY and
+    # duty cycle are correct. Two half-working sources, merged.
+    try:
+        import torch_xla as _txla
+        import torch_xla.core.xla_model as _xm
+
+        real = _txla._XLAC._xla_get_all_runtime_devices()
+        infos = [_xm.get_memory_info(d) for d in real]
+        x_used = max(i["bytes_used"] for i in infos)
+        x_total = max(i["bytes_limit"] for i in infos)
+        if used_b == 0 and x_used > 0:
+            used_b, src_used = x_used, "xla"
+        if total_b == 0 and x_total > 0:
+            total_b, src_total = x_total, "xla"
+        if not detail:
+            detail = f"{len(real)} runtime device(s)"
+    except Exception as exc:  # noqa: BLE001 - diagnostic only, never fatal
+        out.append(f"note: xla memory_info unavailable "
+                   f"({type(exc).__name__}: {str(exc)[:110]})")
+
+    if total_b and used_b:
+        out.insert(0, f"hbm: peak {gib(used_b)} of {gib(total_b)} per chip — {detail} "
+                      f"(total via {src_total}, used via {src_used}; "
+                      f"working ceiling 29 GiB on v6e)")
+    elif total_b:
+        out.insert(0, f"hbm: {gib(total_b)} per chip — {detail} (via {src_total}), "
+                      f"under 1 MiB resident. Expected when nothing large is live: "
+                      f"XLA elides allocations no computation consumes, so a "
+                      f"synthetic buffer may never exist. Run --load-backbone for a "
+                      f"real figure. Working ceiling 29 GiB.")
+    else:
+        out.insert(0, "hbm: no source reported chip memory")
+    return out
+
+
+def check_backend() -> int:
+    """Acceptance test for src/backend/ on real TPU silicon.
+
+    Exercises every abstract method. The two that matter most are asserted
+    rather than merely printed:
+
+      * data_parallel_size must be the CHIP count, not the process count. Under
+        SPMD world_size is 1; deriving a per-device batch from it would hand
+        every chip the full global batch.
+      * make_sampler MUST return None. SPMD is one process, so a
+        DistributedSampler would silently train on 1/N of the dataset.
+    """
+    import torch
+
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent.parent))
+    from src.backend import create_backend
+
+    b = create_backend()
+    b.setup()
+    print(f"backend: {b.describe()}", flush=True)
+
+    failures: list[str] = []
+
+    if b.name != "tpu":
+        failures.append(f"expected the tpu backend, got {b.name!r} "
+                        "(is TAYAVISION_TPU=1 set?)")
+
+    dp = b.data_parallel_size
+    print(f"  data_parallel_size = {dp} (world_size = {b.world_size})", flush=True)
+    if dp <= 1:
+        failures.append(f"data_parallel_size is {dp}; expected the chip count")
+    if b.world_size != 1:
+        failures.append(f"SPMD world_size should be 1, got {b.world_size}")
+
+    sampler = b.make_sampler(object(), shuffle=True, seed=0)
+    print(f"  make_sampler -> {sampler!r}", flush=True)
+    if sampler is not None:
+        failures.append("make_sampler must return None under SPMD; a "
+                        "DistributedSampler would train on 1/N of the data")
+
+    # A real parameter, a real backward, a real optimizer step through the seam.
+    lin = torch.nn.Linear(2048, 2048, dtype=torch.bfloat16).to(b.device)
+    lin = b.wrap_model(lin)
+    print(f"  wrap_model -> {type(lin).__name__}", flush=True)
+    opt = torch.optim.SGD(lin.parameters(), lr=1e-4)
+    with b.autocast(torch.bfloat16):
+        out = lin(torch.randn(4, 196, 2048, device=b.device, dtype=torch.bfloat16))
+        loss = out.float().mean()
+    loss.backward()
+    b.optimizer_step(opt)
+    b.sync()
+    print(f"  autocast + backward + optimizer_step ok (loss={loss.item():.6f})", flush=True)
+
+    b.manual_seed(1234)
+    b.barrier()
+    mem = b.memory_info()
+    print(f"  memory_info -> {mem}", flush=True)
+    if not mem.get("total_gib"):
+        failures.append("memory_info reported no total_gib")
+
+    b.cleanup()
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}", flush=True)
+        return 1
+    print("backend-check-ok: every seam method exercised on TPU", flush=True)
+    print("Reached maximum training steps", flush=True)
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--steps", type=int, default=STEPS)
+    ap.add_argument(
+        "--load-backbone",
+        action="store_true",
+        help="also materialize the real model (needs an authorised HF_TOKEN)",
+    )
+    ap.add_argument(
+        "--alloc-gib",
+        type=float,
+        default=0.0,
+        help=(
+            "hold N GiB of bf16 on device for the whole run. Use it to prove the "
+            "HBM probe registers real memory: the default matmul is a few MB "
+            "sharded 16 ways, which correctly reads as 0.0 MiB per chip and so "
+            "cannot distinguish 'probe works' from 'probe broken'."
+        ),
+    )
+    ap.add_argument(
+        "--check-backend",
+        action="store_true",
+        help=(
+            "exercise every method of src/backend/ on real silicon. This is the "
+            "seam's acceptance test: a full pipeline/train_alignment.py run needs "
+            "the 13 GB LLaVA-Pretrain corpus staged, but the backend contract can "
+            "and should be validated without it."
+        ),
+    )
+    args, _unknown = ap.parse_known_args()
+
+    print("tayavision tpu_smoke: control-plane check, NOT training", flush=True)
+
+    if args.check_backend:
+        return check_backend()
+
+    try:
+        import torch
+        import torch_xla
+        import torch_xla.core.xla_model as xm
+        import torch_xla.debug.metrics as met
+        import torch_xla.runtime as xr
+    except ImportError as exc:
+        # The single most likely first-boot failure. Diagnoser row 1.
+        print(f"FATAL: torch_xla import failed: {exc}", flush=True)
+        print("       If this is libpython3.12.so.1.0, LD_LIBRARY_PATH was not set —", flush=True)
+        print("       see scripts/tpu/startup_script.sh step 5.", flush=True)
+        return 1
+
+    xr.use_spmd()
+    devices = xm.get_xla_supported_devices()
+    n = xr.global_runtime_device_count()
+    print(f"torch_xla {torch_xla.__version__} | devices={len(devices)} global={n}", flush=True)
+    print(f"mesh: 1-D over {n} chips (SPMD, single process)", flush=True)
+
+    dev = torch_xla.device()  # xm.xla_device() is deprecated in 2.9
+
+    resident_model = None
+    if args.load_backbone:
+        print("loading the real model (gated HF repos — needs HF_TOKEN)", flush=True)
+        # Running as `python scripts/tpu/tpu_smoke.py` puts scripts/tpu/ on
+        # sys.path, not the repo root, and this project is not pip-installed into
+        # the venv. `pipeline/train_*.py` all carry the same insert for the same
+        # reason. Without it: ModuleNotFoundError: No module named 'config'.
+        sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent.parent))
+        try:
+            from config.model_config import TinyAyaVisionConfig
+            from models.tiny_aya_vision import TinyAyaVisionForConditionalGeneration
+
+            cfg = TinyAyaVisionConfig.for_base()
+            model = TinyAyaVisionForConditionalGeneration(cfg).to(dev, dtype=torch.bfloat16)
+            # torch_xla is LAZY: `.to(dev)` only records the transfer. Without an
+            # explicit sync the weights never reach HBM, and a naive `del model`
+            # afterwards means the fit was never actually tested -- the first
+            # version of this reported 18.4 MiB peak for a 4.33B model.
+            torch_xla.sync()
+            n_params = sum(p.numel() for p in model.parameters())
+            n_train = sum(p.numel() for p in model.parameters() if p.requires_grad)
+            print(f"params total={n_params/1e9:.2f}B "
+                  f"trainable={n_train/1e9:.2f}B ({100*n_train/n_params:.0f}%)", flush=True)
+            print("NOTE: the bare constructor freezes only the vision encoder. Phase-1's "
+                  "~11.5M-trainable figure comes from the training pipeline freezing the "
+                  "LLM, not from the model class.", flush=True)
+            # Deliberately kept resident: `model` must stay alive through the
+            # HBM samples below, or this measures nothing.
+            resident_model = model
+        except OSError as exc:
+            print(f"FATAL: gated repo — {exc}", flush=True)
+            print("       .env must carry an authorised HF_TOKEN and reach the VM", flush=True)
+            print("       inside the code tarball. Diagnoser row 2.", flush=True)
+            return 1
+
+    ballast = None
+    if args.alloc_gib > 0:
+        n = int(args.alloc_gib * 1024**3 / 2)  # bf16 = 2 bytes
+        ballast = torch.zeros(n, device=dev, dtype=torch.bfloat16)
+        torch_xla.sync()
+        print(f"ballast: holding {args.alloc_gib:.2f} GiB bf16 on device", flush=True)
+
+    # Shaped like the real projector output: (batch, 196 image tokens, d=2048).
+    x = torch.randn(8, 196, 2048, device=dev, dtype=torch.bfloat16)
+    w = torch.randn(2048, 2048, device=dev, dtype=torch.bfloat16)
+
+    step_times = []
+    for step in range(1, args.steps + 1):
+        # Perturb the input each step. With a constant input XLA caches the
+        # result and every step after the first reports the enqueue time, not
+        # the compute time -- the first version of this script printed
+        # step_time=0.0001 and an identical loss for 18 straight steps.
+        # The SHAPE never changes, so this costs no recompile.
+        x.add_(0.001)
+
+        t0 = time.monotonic()
+        y = (x @ w).relu()
+        loss = y.float().mean()
+        torch_xla.sync()
+        # sync() flushes the graph but does not block on completion. Reading the
+        # value does. Without this the timer measures lazy enqueue.
+        loss_val = loss.item()
+        dt = time.monotonic() - t0
+
+        step_times.append(dt)
+        # Format matched by tpu-watchdog and the WATCH loop in SPEC.md section 4.
+        print(f"step={step} loss={loss_val:.6f} step_time={dt:.4f}", flush=True)
+
+        # Sample mid-run, while tensors are resident and the device is busy.
+        # Sampling only at the end reports duty_cycle 0% every time, which reads
+        # like an idle chip -- the exact signature tpu-diagnoser row 15 keys on.
+        if step == args.steps // 2:
+            for line in hbm_report():
+                print(f"[mid-run] {line}", flush=True)
+
+    if ballast is not None:
+        del ballast  # released only after the final HBM sample
+    if resident_model is not None:
+        del resident_model  # ditto: the model had to survive the HBM samples
+
+    warm = sorted(step_times[3:]) or step_times
+    p50 = warm[len(warm) // 2]
+    print(f"step_time: first={step_times[0]:.4f} p50_warm={p50:.4f} "
+          f"(compile is in the first 2-3 steps)", flush=True)
+
+    for line in hbm_report():
+        print(line, flush=True)
+
+    report = met.metrics_report()
+    print(f"compile-cause markers in report: {report.count('CompileTime')}", flush=True)
+    # NOTE: this script calls .item() every step by design (see above), so
+    # aten::_local_scalar_dense is EXPECTED here and is not a finding. Only
+    # aten::nonzero indicates the dynamic-shape problem the model actually has.
+    if "aten::nonzero" in report:
+        print("WARNING: aten::nonzero present — dynamic-shape fallback. Diagnoser row 11.",
+              flush=True)
+
+    print("Reached maximum training steps", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tpu/train_launcher.sh
+++ b/scripts/tpu/train_launcher.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# train_launcher.sh -- the canonical on-worker launcher.
+#
+# Runs ON the TPU VM, inside tmux `train`. Expects the TAYAVISION_* env to be
+# exported already (startup_script.sh and deploy_tarball.sh both do that).
+#
+# This script's ONLY job is to run the entrypoint and emit the two markers every
+# watcher greps for:
+#
+#     launching <entrypoint> tag=<RUN_TAG>
+#     <entrypoint> exited with status <rc>
+#
+# Change those strings and you break qr_watch, the watchdog agent, and the
+# diagnosis table simultaneously.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/_lib.sh"
+load_env_file
+
+: "${TAYAVISION_RUN_TAG:=$(date -u +%Y%m%d-%H%M%S)-$$}"
+ENTRYPOINT="${TAYAVISION_ENTRYPOINT:-scripts/tpu/tpu_smoke.py}"
+
+cd "$REPO_ROOT"
+
+# --- fail loudly and immediately on a typo'd entrypoint ---------------------
+# Without this you discover the mistake 20 minutes into a spot acquisition, as a
+# confusing python traceback buried in a log nobody is tailing yet.
+if [ ! -f "$ENTRYPOINT" ]; then
+  log "FATAL: entrypoint not found: $ENTRYPOINT"
+  log "       TAYAVISION_ENTRYPOINT must be a repo-relative path."
+  log "       Default is scripts/tpu/tpu_smoke.py."
+  log "       NOTE: pipeline/train_*.py does NOT run on TPU yet --"
+  log "             see .claude/orchestration/SPEC.md section 9."
+  notify "entrypoint missing: $ENTRYPOINT" "tayavision FAILED"
+  exit 2
+fi
+
+# --- torch_xla needs libpython on the loader path --------------------------
+# _XLAC.so dynamically links libpython3.12.so.1.0, which uv keeps outside the
+# default path. Without this, `import torch_xla` dies with ImportError.
+if [ -z "${LD_LIBRARY_PATH:-}" ] || ! printf '%s' "$LD_LIBRARY_PATH" | grep -q libpython; then
+  LIBPYTHON_DIR="$(find "${UV_PYTHON_ROOT:-$HOME/.local/share/uv/python}" \
+                     -name 'libpython3.12.so.1.0' -printf '%h\n' 2>/dev/null | head -1)"
+  if [ -n "$LIBPYTHON_DIR" ]; then
+    export LD_LIBRARY_PATH="${LIBPYTHON_DIR}:${LD_LIBRARY_PATH:-}"
+    log "LD_LIBRARY_PATH += $LIBPYTHON_DIR"
+  fi
+fi
+
+export PJRT_DEVICE=TPU
+export TAYAVISION_TPU=1
+export TPU_STRATEGY="${TPU_STRATEGY:-replicated}"
+
+# Route Hydra entrypoints to the TPU W&B project by DEFAULT, not by remembering.
+#
+# `pipeline/train_*.py` calls wandb.init(project=cfg.wandb.project, ...), and an
+# explicit arg beats the WANDB_PROJECT env var. config/config.yaml says
+# `tayavision-instruct-sweep`, so a TPU run that forgets the override lands its
+# metrics in a GPU RESULTS project. Injecting the override here makes .env the
+# single source of truth and removes the footgun.
+#
+# Only for pipeline/ entrypoints (tpu_smoke.py is argparse, not Hydra), and only
+# when the caller has not already said something about wandb.
+case "$ENTRYPOINT" in
+  pipeline/*)
+    if [ -n "${WANDB_PROJECT:-}" ] && \
+       ! printf '%s' "${TAYAVISION_HYDRA_OVERRIDES:-}" | grep -q 'wandb\.project'; then
+      TAYAVISION_HYDRA_OVERRIDES="${TAYAVISION_HYDRA_OVERRIDES:-} wandb.project=${WANDB_PROJECT}"
+      log "  injected wandb.project=${WANDB_PROJECT} from .env"
+    fi
+    if [ -n "${WANDB_ENTITY:-}" ] && \
+       ! printf '%s' "${TAYAVISION_HYDRA_OVERRIDES:-}" | grep -q 'wandb\.entity'; then
+      TAYAVISION_HYDRA_OVERRIDES="${TAYAVISION_HYDRA_OVERRIDES:-} wandb.entity=${WANDB_ENTITY}"
+      log "  injected wandb.entity=${WANDB_ENTITY} from .env"
+    fi
+    # train_multilingual.py hardcodes project="tayavision-multilingual" and
+    # ignores the Hydra override entirely -- this injection cannot save it.
+    # One-line fix, tracked as PLAN P6.
+    case "$ENTRYPOINT" in
+      *train_multilingual.py)
+        log "  WARNING: train_multilingual.py ignores wandb.project and will write to"
+        log "           'tayavision-multilingual' (a GPU results project). See PLAN P6." ;;
+    esac
+    ;;
+esac
+# W&B: export only when non-empty. An empty WANDB_* export makes wandb.init die
+# with "Run ID cannot be empty" -- diagnoser row 18.
+[ -n "${WANDB_RUN_NAME:-}" ] && export WANDB_RUN_NAME
+[ -n "${WANDB_RUN_ID:-}" ] && export WANDB_RUN_ID
+
+log "launching $ENTRYPOINT tag=$TAYAVISION_RUN_TAG"
+# Print what is actually in the environment. This line used to read
+# `${TAYAVISION_RESUME:-auto}`, which reported "resume=auto" whenever the
+# variable was unset -- while nothing read the variable at all. A banner that
+# invents a value it does not pass on is worse than no banner.
+log "  strategy=$TPU_STRATEGY resume=${TAYAVISION_RESUME:-off}"
+log "  overrides='${TAYAVISION_HYDRA_OVERRIDES:-}'"
+log "  ckpt=${SAVE_CKPT_DIR:-<local, NOT durable>}"
+
+UV_BIN="$(command -v uv || echo /root/.local/bin/uv)"
+
+# shellcheck disable=SC2086
+"$UV_BIN" run --no-sync python -u "$ENTRYPOINT" ${TAYAVISION_HYDRA_OVERRIDES:-}
+rc=$?
+# ^ rc MUST be captured on its own line. A $(date) or any command substitution
+#   on the same line as $? resets it, and every exit status reads 0. That bug
+#   made a sibling project's launcher report success for every fatal traceback.
+
+log "$ENTRYPOINT exited with status $rc"
+
+if [ "$rc" -eq 0 ]; then
+  notify "run OK — $(tail -3 /tmp/train.log 2>/dev/null | tr '\n' ' ' | cut -c1-160)" "tayavision"
+else
+  notify "run FAILED rc=$rc — $(tail -3 /tmp/train.log 2>/dev/null | tr '\n' ' ' | cut -c1-160)" "tayavision FAILED"
+fi
+
+exit "$rc"

--- a/src/backend/__init__.py
+++ b/src/backend/__init__.py
@@ -1,0 +1,19 @@
+"""Accelerator backend seam.
+
+`create_backend()` is the only thing callers need. It selects from the
+environment and defers the import, so a GPU box never touches `torch_xla`:
+
+    from src.backend import create_backend
+
+    backend = create_backend()
+    backend.setup()
+    model = backend.wrap_model(model.to(backend.device))
+
+Do NOT import `src.backend.tpu_backend` directly from shared code --
+`scripts/ci/check_backend_seam.sh` exists to keep `torch_xla` out of the import
+graph of everything except that one module.
+"""
+
+from src.backend.base import Backend, create_backend
+
+__all__ = ["Backend", "create_backend"]

--- a/src/backend/base.py
+++ b/src/backend/base.py
@@ -1,0 +1,179 @@
+"""Backend seam: the contract every accelerator path implements.
+
+Why this exists
+---------------
+`pipeline/train_*.py` used to hardcode CUDA and DDP: `torch.autocast("cuda")`,
+`torch.device(f"cuda:{rank}")`, `torch.cuda.manual_seed_all`,
+`DistributedDataParallel`, `DistributedSampler`. None of that runs under
+torch_xla, and inlining `if tpu: ... else: ...` at every call site would make the
+Modal/GPU path -- which produced every published number -- something you have to
+re-verify on every TPU change.
+
+So the accelerator-specific behaviour lives behind this ABC, and exactly one
+module is allowed to `import torch_xla` at module scope:
+`src/backend/tpu_backend.py`. `scripts/ci/check_backend_seam.sh` enforces that.
+A module-level `import torch_xla` anywhere in the shared trees drags `libtpu`
+into the import graph and breaks every CPU/GPU run and the whole test suite.
+
+Selection is by environment, not by import:
+    TAYAVISION_TPU=1  ->  TPUBackend      (set by scripts/tpu/train_launcher.sh)
+    otherwise         ->  GPUBackend      (DDP + CUDA, unchanged)
+"""
+
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from contextlib import AbstractContextManager
+from typing import Any
+
+import torch
+
+
+class Backend(ABC):
+    """One accelerator strategy: device placement, distribution, stepping."""
+
+    name: str = "base"
+
+    # --- topology -----------------------------------------------------------
+
+    @property
+    @abstractmethod
+    def device(self) -> torch.device:
+        """The device tensors and the model should live on."""
+
+    @property
+    @abstractmethod
+    def rank(self) -> int:
+        """Global process rank. 0 when not distributed."""
+
+    @property
+    @abstractmethod
+    def world_size(self) -> int:
+        """Number of participating processes.
+
+        NOTE this is *processes*, not chips. Under SPMD it is 1 even on a
+        64-chip slice -- one process drives the whole mesh. Anything that
+        divides a global batch by this must account for that.
+        """
+
+    @property
+    def local_rank(self) -> int:
+        return self.rank
+
+    @property
+    def is_main(self) -> bool:
+        return self.rank == 0
+
+    @property
+    @abstractmethod
+    def data_parallel_size(self) -> int:
+        """How many ways the *data* is split.
+
+        Equals `world_size` under DDP, and the chip count under SPMD. This --
+        not `world_size` -- is what a per-device batch size should be derived
+        from.
+        """
+
+    # --- lifecycle ----------------------------------------------------------
+
+    @abstractmethod
+    def setup(self) -> None:
+        """Initialise process groups / runtime. Idempotent."""
+
+    @abstractmethod
+    def cleanup(self) -> None:
+        """Tear down. Safe to call when setup never ran."""
+
+    @abstractmethod
+    def barrier(self) -> None:
+        """Synchronise all processes. No-op when not distributed."""
+
+    # --- compute ------------------------------------------------------------
+
+    @abstractmethod
+    def autocast(self, dtype: torch.dtype) -> AbstractContextManager:
+        """Mixed-precision context for this backend's device type."""
+
+    @abstractmethod
+    def manual_seed(self, seed: int) -> None:
+        """Seed the accelerator RNG in addition to torch's CPU RNG."""
+
+    @abstractmethod
+    def wrap_model(self, model: torch.nn.Module, **kwargs: Any) -> torch.nn.Module:
+        """Apply the distribution strategy. May return the model unchanged."""
+
+    @abstractmethod
+    def optimizer_step(self, optimizer: torch.optim.Optimizer) -> None:
+        """Step the optimizer, including any backend-specific graph flush."""
+
+    @abstractmethod
+    def sync(self) -> None:
+        """Flush pending work. No-op on eager backends."""
+
+    # --- data ---------------------------------------------------------------
+
+    @abstractmethod
+    def make_sampler(self, dataset: Any, *, shuffle: bool, seed: int) -> Any | None:
+        """A distributed sampler, or None when the backend must not shard.
+
+        Returning None matters: under SPMD there is ONE process, so a
+        `DistributedSampler` would hand it a 1/N shard and it would train on
+        1/N of the data while reporting nothing wrong.
+        """
+
+    @abstractmethod
+    def wrap_loader(self, loader: Any) -> Any:
+        """Wrap a DataLoader for device feeding. Identity on GPU."""
+
+    # --- checkpointing ------------------------------------------------------
+
+    @abstractmethod
+    def save(self, obj: Any, path: Any) -> None:
+        """Persist `obj`, which may contain device tensors.
+
+        CALL THIS ON EVERY RANK. Moving tensors off the accelerator is device
+        work, and on SPMD device work is collective -- if only rank 0 calls it,
+        the mesh desynchronises and the run deadlocks with no traceback. The
+        implementation decides which rank writes the bytes; the caller must not.
+        """
+
+    # --- diagnostics --------------------------------------------------------
+
+    @abstractmethod
+    def memory_info(self) -> dict[str, float]:
+        """Best-effort {used_gib, total_gib}. Empty dict when unavailable."""
+
+    @property
+    @abstractmethod
+    def addressable_device_count(self) -> int:
+        """Devices owned by THIS process."""
+
+    @abstractmethod
+    def check_topology(self, *, global_batch: int) -> list[str]:
+        """Startup guards. Returns problems; empty list means healthy."""
+
+    def describe(self) -> str:
+        return (f"{self.name}: device={self.device} rank={self.rank}/"
+                f"{self.world_size} dp={self.data_parallel_size}")
+
+
+def create_backend(force: str | None = None) -> Backend:
+    """Select a backend from the environment.
+
+    Imports are deferred into the branches on purpose: importing
+    `tpu_backend` pulls in `torch_xla`, and that must not happen on a GPU box.
+    """
+    choice = (force or os.environ.get("TAYAVISION_BACKEND") or "").lower()
+    if not choice:
+        choice = "tpu" if os.environ.get("TAYAVISION_TPU") == "1" else "gpu"
+
+    if choice == "tpu":
+        from src.backend.tpu_backend import TPUBackend
+
+        return TPUBackend()
+    if choice == "gpu":
+        from src.backend.gpu_backend import GPUBackend
+
+        return GPUBackend()
+    raise ValueError(f"Unknown backend {choice!r}; expected 'gpu' or 'tpu'")

--- a/src/backend/gpu_backend.py
+++ b/src/backend/gpu_backend.py
@@ -1,0 +1,164 @@
+"""CUDA + DDP backend -- the authoritative path.
+
+Every published number, checkpoint, and eval came from this code. It is an
+extraction, not a rewrite: each method below does exactly what the corresponding
+lines of `pipeline/train_alignment.py` and `pipeline/utils.py` did before the
+seam existed, including the details that look incidental.
+
+If you are tempted to "improve" something here, don't. Behaviour changes belong
+in a separate commit with a re-run behind them.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import AbstractContextManager
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data.distributed import DistributedSampler
+
+from src.backend.base import Backend
+
+
+class GPUBackend(Backend):
+    name = "gpu"
+
+    def __init__(self) -> None:
+        # `is_torchrun()` in pipeline/utils.py -- kept as the same LOCAL_RANK
+        # probe rather than importing it, so src/ does not depend on pipeline/.
+        self._use_ddp = "LOCAL_RANK" in os.environ
+        self._local_rank = 0
+        self._rank = 0
+        self._world_size = 1
+        self._device: torch.device | None = None
+
+    # --- topology -----------------------------------------------------------
+
+    @property
+    def device(self) -> torch.device:
+        if self._device is None:
+            # Matches the pre-seam branch exactly: an explicit cuda:<local_rank>
+            # under torchrun, otherwise cuda-if-available with a CPU fallback.
+            # The CPU fallback is load-bearing -- the test suite runs on it.
+            self._device = (
+                torch.device(f"cuda:{self._local_rank}")
+                if self._use_ddp
+                else torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            )
+        return self._device
+
+    @property
+    def rank(self) -> int:
+        return self._rank
+
+    @property
+    def world_size(self) -> int:
+        return self._world_size
+
+    @property
+    def local_rank(self) -> int:
+        return self._local_rank
+
+    @property
+    def data_parallel_size(self) -> int:
+        # Under DDP one process drives one GPU, so these coincide.
+        return self._world_size
+
+    # --- lifecycle ----------------------------------------------------------
+
+    def setup(self) -> None:
+        if not self._use_ddp or dist.is_initialized():
+            return
+        self._local_rank = int(os.environ["LOCAL_RANK"])
+        torch.cuda.set_device(self._local_rank)
+        dist.init_process_group(
+            backend="nccl",
+            device_id=torch.device(f"cuda:{self._local_rank}"),
+        )
+        self._rank = dist.get_rank()
+        self._world_size = dist.get_world_size()
+        self._device = None  # recompute now that local_rank is known
+
+    def cleanup(self) -> None:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def barrier(self) -> None:
+        if dist.is_initialized():
+            dist.barrier()
+
+    # --- compute ------------------------------------------------------------
+
+    def autocast(self, dtype: torch.dtype) -> AbstractContextManager:
+        return torch.autocast("cuda", dtype=dtype)
+
+    def manual_seed(self, seed: int) -> None:
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+
+    def wrap_model(self, model: torch.nn.Module, **kwargs: Any) -> torch.nn.Module:
+        if not self._use_ddp:
+            return model
+        return DDP(model, device_ids=[self._local_rank], **kwargs)
+
+    def optimizer_step(self, optimizer: torch.optim.Optimizer) -> None:
+        optimizer.step()
+
+    def sync(self) -> None:
+        return None  # CUDA is eager from the caller's point of view
+
+    # --- data ---------------------------------------------------------------
+
+    def make_sampler(self, dataset: Any, *, shuffle: bool, seed: int) -> Any | None:
+        if not self._use_ddp:
+            return None
+        return DistributedSampler(
+            dataset,
+            num_replicas=self._world_size,
+            rank=self._rank,
+            shuffle=shuffle,
+            seed=seed,
+        )
+
+    def wrap_loader(self, loader: Any) -> Any:
+        return loader
+
+    # --- checkpointing ------------------------------------------------------
+
+    def save(self, obj: Any, path: Any) -> None:
+        """Rank 0 writes; the others return immediately.
+
+        Unchanged from the pre-seam behaviour, where the caller wrapped the
+        save in `if is_main`. Under DDP that is safe -- nothing here is
+        collective, so the non-writers can simply skip it.
+        """
+        if self.is_main:
+            torch.save(obj, path)
+
+    @property
+    def addressable_device_count(self) -> int:
+        return 1  # one process drives one GPU under DDP
+
+    def check_topology(self, *, global_batch: int) -> list[str]:
+        # Same contract as the TPU path so callers need no branch. Under DDP
+        # processes and devices coincide, so there is only one divisor to check.
+        if global_batch % self._world_size:
+            return [
+                f"global batch {global_batch} not divisible by world_size "
+                f"{self._world_size}"
+            ]
+        return []
+
+    # --- diagnostics --------------------------------------------------------
+
+    def memory_info(self) -> dict[str, float]:
+        if not torch.cuda.is_available():
+            return {}
+        free_b, total_b = torch.cuda.mem_get_info()
+        return {
+            "used_gib": (total_b - free_b) / 1024**3,
+            "total_gib": total_b / 1024**3,
+        }

--- a/src/backend/tpu_backend.py
+++ b/src/backend/tpu_backend.py
@@ -1,0 +1,515 @@
+"""torch_xla SPMD backend -- experimental.
+
+**This is the only module in the repo allowed a module-level `import torch_xla`.**
+`scripts/ci/check_backend_seam.sh` enforces that. A module-level import anywhere
+in `src/`, `models/`, `pipeline/`, or `config/` drags `libtpu` into the import
+graph, which breaks every CPU/GPU run and all 129 tests.
+
+Measured on a live v6e-16 (2026-07-25) -- see
+`.claude/orchestration/playbook/baseline-v6e8-siglip-cohere2.md`:
+
+  * the 4.33B model materializes at **8.058 GiB per chip** of 31.246 GiB
+  * so `replicated` fits with ~21 GiB of headroom under the 29 GiB ceiling
+
+That is why `replicated` is the default and FSDPv2 is opt-in: wrapping each of
+the 36 `Cohere2DecoderLayer`s produces 36 bf16 reduce-scatters and hits
+pytorch/xla #8591 / #8778 (NaN at step ~24-130) on this exact backbone. At this
+parameter budget that risk is avoidable rather than survivable.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import AbstractContextManager
+from typing import Any
+
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.parallel_loader as pl
+import torch_xla.runtime as xr
+
+from src.backend.base import Backend
+
+
+class _XLADeviceModule:
+    """The bare minimum `torch.utils.checkpoint` needs to see for device "xla".
+
+    Gradient checkpointing is mandatory here -- it is what keeps activations to
+    per-layer boundaries (~8.7 GiB/chip instead of something that will not fit).
+    But `torch.utils.checkpoint` cannot run on XLA out of the box:
+
+        checkpoint.py:92   def _get_device_module(device): return getattr(torch, device)
+        checkpoint.py:132  _infer_device_type() -> "xla"   (tensors are on xla, no cuda)
+        checkpoint.py:1476 device_module = _get_device_module(device_type)   # UNCONDITIONAL
+
+    and `torch.xla` does not exist -- the module is `torch_xla` -- so it raises
+    `AttributeError: module 'torch' has no attribute 'xla'` before step 1.
+    Line 1476 runs BEFORE the `if preserve_rng_state:` guard, which is why
+    passing `preserve_rng_state=False` does not avoid it, and
+    `DefaultDeviceType.set_device_type()` does not help either because that only
+    applies when there are NO non-CPU tensors.
+
+    The one thing torch then asks of the module is:
+
+        checkpoint.py:1496  if getattr(device_module, "_initialized", False):
+                                fwd_devices, fwd_device_states = get_device_states(*args)
+
+    So a module that deliberately does **not** define `_initialized` makes torch
+    skip RNG stashing entirely, and `get_device_states` -- which would call
+    `.device()` / `.get_rng_state()` that torch_xla has no module-level
+    equivalent for -- is never reached.
+
+    That skip is semantically right, not a dodge: XLA RNG is managed through
+    `xm.set_rng_state`, not torch's per-device generator, and this backend seeds
+    it in `manual_seed`. Deliberately NOT registering `torch_xla` itself, which
+    carries a large surface that other torch code could then discover.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostic only
+        return "<tayavision xla device-module shim>"
+
+
+def _register_xla_device_module() -> None:
+    """Make `getattr(torch, "xla")` resolve. Idempotent."""
+    if hasattr(torch, "xla"):
+        return
+    shim = _XLADeviceModule()
+    register = getattr(torch, "_register_device_module", None)
+    if register is not None:
+        try:
+            register("xla", shim)
+            return
+        except Exception:  # noqa: BLE001 - already registered, or refused
+            if hasattr(torch, "xla"):
+                return
+    # Fall back to a plain attribute: the only contract torch.utils.checkpoint
+    # has with this object is `getattr(module, "_initialized", False)`.
+    torch.xla = shim  # type: ignore[attr-defined]
+
+
+def _to_cpu(obj: Any) -> Any:
+    """Recursively pull tensors to CPU, leaving everything else alone.
+
+    Written out rather than reusing `xm._maybe_convert_to_cpu` for two reasons:
+    that helper is private, and its `convert=` flag is the very footgun this
+    exists to avoid (see `TPUBackend.save`). Here the transfer is
+    unconditional, so it is identical on every rank by construction.
+    """
+    if torch.is_tensor(obj):
+        return obj.detach().to("cpu")
+    if isinstance(obj, dict):
+        return {k: _to_cpu(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_to_cpu(v) for v in obj]
+    if isinstance(obj, tuple):
+        # Preserve namedtuples, which take positional args rather than an iterable.
+        vals = [_to_cpu(v) for v in obj]
+        return type(obj)(*vals) if hasattr(obj, "_fields") else tuple(vals)
+    return obj
+
+
+def _assert_checkpoint_contract() -> None:
+    """Run one real non-reentrant checkpoint on device, at setup, and fail loud.
+
+    WHY THIS EXISTS
+    ---------------
+    Everything the shim above does rests on torch internals that are private and
+    that provably move between releases. `torch/nn/parallel/_functions.py` used
+    `getattr(torch, device.type, None)` in 2.6.0 and was rewritten to
+    `torch.accelerator` in 2.9.1 -- one risk site vanished between the venv this
+    was authored in and the VM that runs it. `scripts/tpu/startup_script.sh`
+    installs `torch==${TORCH_VERSION:-2.9.*}`, a WILDCARD resolved at
+    provisioning time, so the torch under this shim can change without a commit.
+
+    Two upstream changes would break the shim, and both are plausible:
+
+      * `getattr(device_module, "_initialized", False)` (checkpoint.py:1496)
+        becomes `device_module.is_initialized()`. torch is already moving that
+        way -- `torch/distributed/device_mesh.py:506` and
+        `torch/_subclasses/fake_tensor.py:719` both call `is_initialized()` with
+        NO default. The shim would then raise AttributeError.
+      * `_get_device_module` stops being a bare `getattr(torch, device)`.
+
+    Neither is caught by anything else. `tests/` cannot import this module (it
+    needs libtpu), and `scripts/ci/check_backend_seam.sh` only checks import
+    placement. So the shim's contract is asserted NOWHERE -- which is exactly
+    how a safety argument decays into a stale comment.
+
+    This runs the real thing: a non-reentrant checkpoint over an XLA tensor with
+    `preserve_rng_state=True`, which is the precise configuration
+    `pipeline/train_alignment.py` uses. It touches `_get_device_module`,
+    `_infer_device_type`, the `_initialized` gate, `fork_rng(device_type="xla")`,
+    and the autocast capture/replay -- every internal the shim depends on. Costs
+    one tiny HLO compile (<1s, 4x4 matmul) against a v6e-16 run measured in
+    hours.
+
+    Set TAYAVISION_SKIP_CKPT_CONTRACT=1 to skip. Do that only to get a diagnostic
+    run past a KNOWN break -- gradient checkpointing is not optional at this
+    memory budget, so skipping this does not make the run work, it only moves the
+    failure somewhere less legible.
+    """
+    if os.environ.get("TAYAVISION_SKIP_CKPT_CONTRACT") == "1":
+        return
+
+    from torch.utils.checkpoint import checkpoint
+
+    dev = torch_xla.device()
+    lin = torch.nn.Linear(4, 4).to(dev)
+    x = torch.randn(2, 4, device=dev, requires_grad=True)
+
+    try:
+        # Mirror the trainer exactly: non-reentrant, preserve_rng_state default
+        # (True), under this backend's autocast.
+        with torch.autocast("xla", dtype=torch.bfloat16):
+            out = checkpoint(lambda t: lin(t).relu(), x, use_reentrant=False)
+        out.sum().backward()
+        torch_xla.sync()
+    except Exception as exc:  # noqa: BLE001 - re-raised with the diagnosis
+        raise RuntimeError(
+            "XLA gradient-checkpointing contract FAILED. The `torch.xla` shim in "
+            "src/backend/tpu_backend.py no longer satisfies torch.utils.checkpoint.\n"
+            f"  torch={torch.__version__} "
+            f"torch_xla={getattr(torch_xla, '__version__', 'unknown')}\n"
+            f"  underlying: {type(exc).__name__}: {exc}\n"
+            "Re-diff torch/utils/checkpoint.py (_get_device_module, "
+            "_infer_device_type, the `_initialized` gate, the fork_rng call) and "
+            "torch/random.py against the version this shim was written for "
+            "(2.6.0 / 2.9.1). Do NOT paper over it by adding attributes to "
+            "_XLADeviceModule until you know which gate flipped -- a guessed "
+            "attribute turns a loud AttributeError into a silently wrong device."
+        ) from exc
+
+    if x.grad is None:
+        raise RuntimeError(
+            "XLA gradient-checkpointing contract FAILED: backward through "
+            "checkpoint produced no gradient. Activations would be recomputed "
+            "for nothing and the projector would never train."
+        )
+
+
+class TPUBackend(Backend):
+    name = "tpu"
+
+    def __init__(self) -> None:
+        self._strategy = os.environ.get("TPU_STRATEGY", "replicated").lower()
+        self._device: torch.device | None = None
+        self._setup_done = False
+        self._mesh = None
+
+    # --- topology -----------------------------------------------------------
+
+    @property
+    def device(self) -> torch.device:
+        if self._device is None:
+            self._device = torch_xla.device()
+        return self._device
+
+    @property
+    def rank(self) -> int:
+        """Index of THIS process among the hosts. 0..process_count-1.
+
+        `xr.process_index()`, NOT `xr.global_ordinal()`. Measured on the v6e-16
+        (2026-07-25): `global_ordinal()` returns **0 on every host** and
+        `world_size()` returns **1 on every host** -- those are the non-SPMD
+        values and are useless here. Using them would make host sharding a
+        silent no-op, with all four hosts training on shard 0.
+
+        Also note process_index is NOT the gcloud worker number: measured
+        w-0->2, w-1->0, w-2->1, w-3->3. It is a valid permutation (each index
+        appears exactly once), which is all sharding needs -- but it means the
+        `is_main` process, and therefore the W&B writer, was on **worker 1**.
+        Do not go looking for the wandb log on worker 0.
+        """
+        return xr.process_index()
+
+    @property
+    def world_size(self) -> int:
+        """Number of PROCESSES (= hosts). 4 on the v6e-16, 1 on a v6e-8.
+
+        This is what the DataLoader batch divides by. Not the chip count.
+        """
+        return xr.process_count()
+
+    @property
+    def data_parallel_size(self) -> int:
+        """Total CHIPS across all hosts -- 16 on the v6e-16.
+
+        Distinct from `world_size` (4 processes). The mesh shards across chips;
+        the DataLoader splits across processes. Conflating the two is what made
+        `batch_size % world_size` fail at 8 % 16.
+        """
+        return xr.global_runtime_device_count()
+
+    @property
+    def addressable_device_count(self) -> int:
+        """Chips owned by THIS process. 4 on the v6e-16."""
+        return xr.addressable_runtime_device_count()
+
+    # --- lifecycle ----------------------------------------------------------
+
+    def setup(self) -> None:
+        if self._setup_done:
+            return
+        xr.use_spmd()
+        _register_xla_device_module()
+        # Assert the shim's contract on real silicon before anything expensive
+        # happens. A break here costs one compile; the same break discovered at
+        # the first backward costs the model load, the dataset scan, and the
+        # slice time to get there.
+        _assert_checkpoint_contract()
+        self._setup_done = True
+
+    def cleanup(self) -> None:
+        # Flush anything still queued so a checkpoint write is not left pending.
+        try:
+            torch_xla.sync()
+        except Exception:  # noqa: BLE001 - teardown must never raise
+            pass
+
+    def barrier(self) -> None:
+        # One process: nothing to synchronise with. Still flush, because callers
+        # use barrier() to mean "everything before this is done".
+        torch_xla.sync()
+
+    # --- compute ------------------------------------------------------------
+
+    def autocast(self, dtype: torch.dtype) -> AbstractContextManager:
+        return torch.autocast("xla", dtype=dtype)
+
+    def manual_seed(self, seed: int) -> None:
+        torch.manual_seed(seed)
+        xm.set_rng_state(seed)
+
+    def wrap_model(self, model: torch.nn.Module, **kwargs: Any) -> torch.nn.Module:
+        if self._strategy == "replicated":
+            # Nothing to wrap: SPMD replicates by default and the model fits.
+            return model
+
+        if self._strategy in ("fsdpv2", "fsdpv2_lora"):
+            from torch_xla.distributed.spmd.xla_sharding import Mesh
+            from torch_xla.experimental.spmd_fully_sharded_data_parallel import (
+                SpmdFullyShardedDataParallel as FSDPv2,
+            )
+
+            num_devices = xr.global_runtime_device_count()
+            mesh = Mesh(list(range(num_devices)), (num_devices, 1), ("fsdp", "model"))
+
+            # DO NOT add Cohere2DecoderLayer to this policy. 36 per-layer wraps
+            # => 36 bf16 reduce-scatters => NaN at step ~24-130. FSDPv2 has no
+            # fp32_reduce_scatter (FSDPv1 only, #3588/#8056). One outer wrap.
+            #
+            # The policy matches on type(module).__name__: a stale class name
+            # wraps NOTHING, silently falls back to replicated, and looks like a
+            # successful FSDPv2 run. Verify the wrap count before trusting it.
+            return FSDPv2(model, mesh=mesh, **kwargs)
+
+        raise ValueError(
+            f"Unknown TPU_STRATEGY {self._strategy!r}; "
+            "expected 'replicated', 'fsdpv2', or 'fsdpv2_lora'"
+        )
+
+    def optimizer_step(self, optimizer: torch.optim.Optimizer) -> None:
+        # Under SPMD there is one process, so there is no gradient all-reduce to
+        # perform here -- sharding handles it. `xm.optimizer_step` would add a
+        # second, redundant reduction. Step, then flush the graph.
+        optimizer.step()
+        torch_xla.sync()
+
+    def sync(self) -> None:
+        torch_xla.sync()
+
+    # --- data ---------------------------------------------------------------
+
+    def make_sampler(self, dataset: Any, *, shuffle: bool, seed: int) -> Any | None:
+        """Shard the dataset across HOSTS, so the epoch is covered exactly once.
+
+        Multi-host (process_count > 1): each host takes 1/N of the data and
+        decodes only its share -- for 558K JPEGs that is the difference between
+        4x redundant decode and none.
+
+        Single-host (process_count == 1): None. One process reads everything and
+        the mesh shards it across the local chips.
+
+        `drop_last=True` is NOT a preference. A short final batch is a different
+        shape, and on XLA a different shape is a new HLO compile -- so without it
+        every epoch ends in a recompile. It costs at most (batch-1) samples per
+        host per epoch; measured at this config, 48 of 558,128 = 0.0086%.
+        """
+        if self.world_size <= 1:
+            return None
+        from torch.utils.data.distributed import DistributedSampler
+
+        return DistributedSampler(
+            dataset,
+            num_replicas=self.world_size,   # hosts, not chips
+            rank=self.rank,                 # process_index, not worker number
+            shuffle=shuffle,
+            seed=seed,
+            drop_last=True,
+        )
+
+    def check_topology(self, *, global_batch: int) -> list[str]:
+        """Startup guards. Returns a list of problems; empty means healthy.
+
+        Every one of these failures is otherwise SILENT -- a mis-sharded run
+        hangs or trains on a malformed global batch without raising. That
+        asymmetry is the whole reason host-sharding needs guarding and
+        replication does not.
+        """
+        problems: list[str] = []
+        procs, chips = self.world_size, self.data_parallel_size
+
+        if global_batch % chips:
+            problems.append(
+                f"global batch {global_batch} not divisible by {chips} chips -- "
+                "the mesh cannot shard it evenly"
+            )
+        if global_batch % procs:
+            problems.append(
+                f"global batch {global_batch} not divisible by {procs} hosts -- "
+                "per-host DataLoader batch would be fractional"
+            )
+        addressable = self.addressable_device_count
+        if procs * addressable != chips:
+            problems.append(
+                f"topology inconsistent: {procs} processes x {addressable} "
+                f"addressable chips != {chips} global chips"
+            )
+        # The minibatch contract, asserted at startup rather than discovered on
+        # the first batch. torch_xla checks this itself in
+        # `xla_model.send_cpu_data_to_device`, but only once data flows -- by
+        # which point we have already paid model load and compile.
+        if procs > 1 and not (global_batch % procs) and addressable:
+            per_host = global_batch // procs
+            if per_host % addressable:
+                problems.append(
+                    f"per-host batch {per_host} (= {global_batch}/{procs} hosts) "
+                    f"not divisible by {addressable} local chips -- "
+                    "ShardingSpec(minibatch=True) requires it"
+                )
+        return problems
+
+    def wrap_loader(self, loader: Any) -> Any:
+        """Feed the device AND shard the batch across chips.
+
+        `input_sharding` is not an optimisation here, it is what makes this data
+        parallel at all. Without it, `replicated` replicates the model to every
+        chip and then hands every chip the WHOLE host batch -- 4 chips each doing
+        identical work on 64 samples, instead of 16 samples each.
+
+        That is how a v6e-16 OOM'd at global batch 256: the HLO showed
+        `bf16[64,640,11008]` = 860 MB per MLP intermediate, i.e. the per-HOST
+        batch of 64, not the per-chip 16. (11008 is Cohere2's FFN intermediate,
+        5.38x the 2048 hidden size -- the dominant activation term.)
+
+        The spec shards dim 0 (batch) over the mesh's `data` axis and replicates
+        the rest, which is textbook SPMD data parallelism.
+
+        `minibatch=True` IS MANDATORY HERE and is not a tuning knob. It is the
+        flag that tells XLA the tensor this host just handed it is the host's
+        SHARD of the global batch, not the global batch itself.
+
+        We are host-sharded: `make_sampler` gives each of the N hosts a disjoint
+        1/N of the dataset, so each host's loader yields `global/N` rows (64 of
+        256 here). The mesh, however, spans all 16 GLOBAL chips -- it has to,
+        because `ShardingSpec.__post_init__` derives its sharding type from
+        `xr.global_runtime_device_count()`.
+
+        With `minibatch=False` (the default) those two facts contradict each
+        other: every host asserts that ITS 64 rows are the global tensor to be
+        split across all 16 chips, and the four hosts disagree about what the
+        global tensor is. Nothing raises -- 64 is divisible by 16, so every
+        shape check passes -- and the program simply never makes progress.
+
+        Measured 2026-07-25, v6e-16, tag deploy-20260725-092930: hung 2h39m with
+        HBM allocated at 17.14 GiB/chip, duty cycle 0%, host CPU 1 jiffy per 5s,
+        main thread in `futex_wait_queue`, zero traceback on all four hosts.
+        That silence is the entire cost of this one keyword.
+
+        With `minibatch=True`, torch_xla instead requires the per-host batch to
+        divide by the LOCAL device count (`xla_model.py:1279`), i.e. 64 % 4 == 0
+        -> 16 rows per chip, 256 global. `check_topology` asserts that up front.
+        """
+        import torch_xla.distributed.spmd as xs
+
+        mesh = self._data_mesh()
+
+        # Each entry of the batch dict is sharded on its batch dimension.
+        # pixel_values is (B, C, H, W); the token tensors are (B, S).
+        minibatch = self.world_size > 1
+        spec = xs.ShardingSpec(mesh, ("data", None), minibatch=minibatch)
+        img_spec = xs.ShardingSpec(
+            mesh, ("data", None, None, None), minibatch=minibatch
+        )
+        return pl.MpDeviceLoader(
+            loader,
+            self.device,
+            input_sharding={
+                "input_ids": spec,
+                "attention_mask": spec,
+                "labels": spec,
+                "pixel_values": img_spec,
+            },
+        )
+
+    # --- checkpointing ------------------------------------------------------
+
+    def save(self, obj: Any, path: Any) -> None:
+        """Every rank transfers; only the global master writes.
+
+        Deliberately NOT `xm.save`. That helper does
+
+            should_write = master_only is False or is_master_ordinal(...)
+            cpu_data = _maybe_convert_to_cpu(data, convert=should_write)
+            if should_write: torch.save(cpu_data, path)
+
+        i.e. it performs the device->host transfer ONLY on the writer
+        (`xla_model.py:1246`). That is precisely the asymmetry that deadlocked
+        this trainer once already: on SPMD the transfer is collective, so a rank
+        that skips it leaves the others waiting forever. `xm.save`'s own
+        docstring papers over this by telling the caller to follow it with
+        `xm.rendezvous(...)`, which is a barrier -- and a barrier cannot repair
+        a mismatch in the collective work itself.
+
+        So: flush, convert on ALL ranks, write on one, meet again.
+        """
+        torch_xla.sync()
+        xm.wait_device_ops()
+        cpu_obj = _to_cpu(obj)
+        if self.is_main:
+            torch.save(cpu_obj, path)
+        self.barrier()
+
+    def _data_mesh(self):
+        """1-D mesh over every chip, named `data`. Cached."""
+        import numpy as np
+        import torch_xla.distributed.spmd as xs
+
+        if self._mesh is None:
+            n = xr.global_runtime_device_count()
+            self._mesh = xs.Mesh(np.arange(n), (n, 1), ("data", "model"))
+        return self._mesh
+
+    # --- diagnostics --------------------------------------------------------
+
+    def memory_info(self) -> dict[str, float]:
+        # xm.get_memory_info() is unusable under SPMD: it defaults to
+        # xla_device(), which is the *virtual* device SPMD:0, and
+        # _xla_memory_info rejects it. libtpu's metrics server works instead.
+        try:
+            from tpu_info import device as tpu_device
+            from tpu_info import metrics as tpu_metrics
+
+            chip_type, _count = tpu_device.get_local_chips()
+            if chip_type is None:
+                return {}
+            usages = tpu_metrics.get_chip_usage(chip_type)
+            return {
+                "used_gib": max(u.memory_usage for u in usages) / 1024**3,
+                "total_gib": max(u.total_memory for u in usages) / 1024**3,
+            }
+        except Exception:  # noqa: BLE001 - diagnostics must never break a run
+            return {}

--- a/src/processing.py
+++ b/src/processing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import torch
 from PIL import Image
-from transformers import AutoImageProcessor, AutoProcessor, AutoTokenizer, ProcessorMixin
+from transformers import AutoImageProcessor, AutoTokenizer, ProcessorMixin
 from transformers.feature_extraction_utils import BatchFeature
 
 from config.model_config import TinyAyaVisionConfig

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,10 +32,30 @@ def device():
     return torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
-# Composed so the tests are both auto-skipped without CUDA *and* deselectable
-# by name: `pytest -m "not requires_gpu"`. A bare skipif carries no marker, so
-# the old version could not be deselected -- you paid full collection cost
-# either way. `requires_gpu` is registered in pyproject.toml.
-requires_gpu = pytest.mark.requires_gpu(
-    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+_skip_without_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA not available"
 )
+
+
+def requires_gpu(obj):
+    """Label a test GPU-only *and* skip it when there is no CUDA device.
+
+    Both properties are wanted: the label makes `pytest -m "not requires_gpu"`
+    able to deselect these before collection cost is paid, and the skip keeps a
+    CPU-only machine green. `requires_gpu` is registered in pyproject.toml.
+
+    This has to be a function. The obvious spelling,
+
+        requires_gpu = pytest.mark.requires_gpu(pytest.mark.skipif(...))
+
+    does NOT compose the two marks. Calling a MarkDecorator with a non-callable
+    argument stores that argument as a *parameter of the mark*, so the result is
+    a bare `requires_gpu` mark carrying the skipif in `mark.args`, and the skip
+    never happens. The tests then run everywhere and error in the fixture on the
+    first `.cuda()`.
+
+    That is invisible on a CUDA box -- which is why it shipped and only CI, on a
+    CPU-only runner, caught it: `RuntimeError: Found no NVIDIA driver`, six
+    errors in test_vision_encoder.py.
+    """
+    return pytest.mark.requires_gpu(_skip_without_cuda(obj))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,10 @@ def device():
     return torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
-requires_gpu = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="CUDA not available"
+# Composed so the tests are both auto-skipped without CUDA *and* deselectable
+# by name: `pytest -m "not requires_gpu"`. A bare skipif carries no marker, so
+# the old version could not be deselected -- you paid full collection cost
+# either way. `requires_gpu` is registered in pyproject.toml.
+requires_gpu = pytest.mark.requires_gpu(
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 )

--- a/tests/test_checkpoint_gcs.py
+++ b/tests/test_checkpoint_gcs.py
@@ -1,0 +1,241 @@
+"""Tests for the gs:// checkpoint mirror in pipeline.utils.
+
+The bug these guard against: `SAVE_CKPT_DIR` used to reach only the shell
+scripts, so `save_checkpoint` wrote to node-local disk while deploy warnings,
+queued-resource metadata, and the `qr_watch.sh` durability gate all reported
+that checkpoints were durable. A preemption then discarded the run.
+
+Everything here mocks `_gcloud_storage`, so no bucket, credentials, or network
+are involved.
+"""
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from pipeline import utils
+
+
+@pytest.fixture
+def ckpt_dir(tmp_path):
+    """A `/models/<run_id>` lookalike -- the parent name IS the run id."""
+    d = tmp_path / "1f7d76da-cb77-43cf-922a-32a9a2891c86"
+    d.mkdir()
+    return d
+
+
+def _write(path: Path) -> Path:
+    path.write_bytes(b"not a real checkpoint")
+    return path
+
+
+class TestCheckpointRoot:
+    def test_unset_is_none(self, monkeypatch):
+        monkeypatch.delenv("SAVE_CKPT_DIR", raising=False)
+        assert utils.gcs_checkpoint_root() is None
+
+    def test_empty_is_none(self, monkeypatch):
+        monkeypatch.setenv("SAVE_CKPT_DIR", "")
+        assert utils.gcs_checkpoint_root() is None
+
+    def test_local_path_is_ignored(self, monkeypatch):
+        """A node-local path must NOT be treated as durable."""
+        monkeypatch.setenv("SAVE_CKPT_DIR", "/models/whatever")
+        assert utils.gcs_checkpoint_root() is None
+
+    def test_trailing_slash_stripped(self, monkeypatch):
+        monkeypatch.setenv("SAVE_CKPT_DIR", "gs://bucket/ckpts/")
+        assert utils.gcs_checkpoint_root() == "gs://bucket/ckpts"
+
+
+class TestCheckpointStep:
+    @pytest.mark.parametrize("name,expected", [
+        ("checkpoint_40.pt", 40),
+        ("checkpoint_2180.pt", 2180),
+        ("gs://b/run/checkpoint_500.pt", 500),
+        ("config.json", -1),
+    ])
+    def test_parsing(self, name, expected):
+        assert utils._checkpoint_step(name) == expected
+
+    def test_latest_is_numeric_not_lexicographic(self, ckpt_dir):
+        """checkpoint_9 must not beat checkpoint_10."""
+        for step in (9, 10, 500):
+            _write(ckpt_dir / f"checkpoint_{step}.pt")
+        assert utils.find_latest_checkpoint(ckpt_dir).name == "checkpoint_500.pt"
+
+
+class TestMirror:
+    def test_noop_without_env(self, ckpt_dir, monkeypatch):
+        monkeypatch.delenv("SAVE_CKPT_DIR", raising=False)
+        with mock.patch.object(utils, "_gcloud_storage") as g:
+            assert utils.mirror_checkpoint_to_gcs(ckpt_dir / "checkpoint_1.pt") is False
+        g.assert_not_called()
+
+    def test_destination_includes_run_id(self, ckpt_dir, monkeypatch):
+        """<root>/<run_id>/<file> -- the layout resume reads back from."""
+        monkeypatch.setenv("SAVE_CKPT_DIR", "gs://tayavision-eu/checkpoints/align")
+        src = _write(ckpt_dir / "checkpoint_500.pt")
+        with mock.patch.object(utils, "_gcloud_storage",
+                               return_value=(True, "", "")) as g:
+            assert utils.mirror_checkpoint_to_gcs(src) is True
+        g.assert_called_once_with(
+            "cp", str(src),
+            f"gs://tayavision-eu/checkpoints/align/{ckpt_dir.name}/checkpoint_500.pt",
+        )
+
+    def test_failure_warns_but_does_not_raise(self, ckpt_dir, monkeypatch, capsys):
+        """A transient bucket error must not kill a multi-hour run -- but it
+        must be loud, since the run only *looks* durable afterwards."""
+        monkeypatch.setenv("SAVE_CKPT_DIR", "gs://bucket/ckpts")
+        src = _write(ckpt_dir / "checkpoint_1.pt")
+        with mock.patch.object(utils, "_gcloud_storage",
+                               return_value=(False, "", "503 backend error")):
+            assert utils.mirror_checkpoint_to_gcs(src) is False
+        out = capsys.readouterr().out
+        assert "WARNING" in out and "503 backend error" in out
+
+
+class TestFetch:
+    def test_noop_without_env(self, ckpt_dir, monkeypatch):
+        monkeypatch.delenv("SAVE_CKPT_DIR", raising=False)
+        with mock.patch.object(utils, "_gcloud_storage") as g:
+            assert utils.fetch_checkpoint_from_gcs(ckpt_dir) is None
+        g.assert_not_called()
+
+    def test_local_checkpoint_wins(self, ckpt_dir, monkeypatch):
+        """A slice that never went away must not re-download."""
+        monkeypatch.setenv("SAVE_CKPT_DIR", "gs://bucket/ckpts")
+        _write(ckpt_dir / "checkpoint_500.pt")
+        with mock.patch.object(utils, "_gcloud_storage") as g:
+            assert utils.fetch_checkpoint_from_gcs(ckpt_dir) is None
+        g.assert_not_called()
+
+    def test_picks_highest_step(self, ckpt_dir, monkeypatch):
+        monkeypatch.setenv("SAVE_CKPT_DIR", "gs://bucket/ckpts")
+        run = ckpt_dir.name
+        listing = "\n".join([
+            f"gs://bucket/ckpts/{run}/checkpoint_500.pt",
+            f"gs://bucket/ckpts/{run}/checkpoint_2000.pt",
+            f"gs://bucket/ckpts/{run}/checkpoint_1000.pt",
+        ])
+        calls = []
+
+        def fake(*args):
+            calls.append(args)
+            if args[0] == "ls":
+                return True, listing, ""
+            _write(ckpt_dir / "checkpoint_2000.pt")
+            return True, "", ""
+
+        with mock.patch.object(utils, "_gcloud_storage", side_effect=fake):
+            got = utils.fetch_checkpoint_from_gcs(ckpt_dir)
+
+        assert got == ckpt_dir / "checkpoint_2000.pt"
+        assert calls[1] == ("cp", f"gs://bucket/ckpts/{run}/checkpoint_2000.pt",
+                            str(ckpt_dir))
+
+    def test_empty_listing_returns_none(self, ckpt_dir, monkeypatch):
+        """A first run has an empty prefix; that is normal, not an error."""
+        monkeypatch.setenv("SAVE_CKPT_DIR", "gs://bucket/ckpts")
+        with mock.patch.object(utils, "_gcloud_storage",
+                               return_value=(False, "", "One or more URLs matched no objects")):
+            assert utils.fetch_checkpoint_from_gcs(ckpt_dir) is None
+
+
+class TestResolveResume:
+    """`TAYAVISION_RESUME` was inert: the launcher printed `resume=auto` and
+    nothing read the variable, so QR metadata and SPEC.md both described a
+    self-heal that could not happen."""
+
+    @pytest.mark.parametrize("value", ["", "off", "none", "NO", "0", "False", "  "])
+    def test_off_values_start_fresh(self, monkeypatch, value):
+        monkeypatch.setenv("TAYAVISION_RESUME", value)
+        with mock.patch.object(utils, "_gcloud_storage") as g:
+            assert utils.resolve_resume_run_id() is None
+        g.assert_not_called()
+
+    def test_unset_starts_fresh(self, monkeypatch):
+        monkeypatch.delenv("TAYAVISION_RESUME", raising=False)
+        assert utils.resolve_resume_run_id() is None
+
+    def test_literal_run_id_passes_through(self, monkeypatch):
+        monkeypatch.setenv("TAYAVISION_RESUME", "a2d64c8e-ab98-405e-95f8-3aa7f1a1835d")
+        with mock.patch.object(utils, "_gcloud_storage") as g:
+            assert utils.resolve_resume_run_id() == "a2d64c8e-ab98-405e-95f8-3aa7f1a1835d"
+        g.assert_not_called(), "a literal id must not need a bucket listing"
+
+    def test_auto_without_gcs_starts_fresh(self, monkeypatch):
+        """auto + node-local checkpoints has nothing durable to resume from."""
+        monkeypatch.setenv("TAYAVISION_RESUME", "auto")
+        monkeypatch.setenv("SAVE_CKPT_DIR", "/models")
+        assert utils.resolve_resume_run_id() is None
+
+    def test_auto_picks_newest_by_timestamp(self, monkeypatch):
+        """Newest wins by mtime, NOT by step number -- a later run legitimately
+        has fewer steps than an earlier long one."""
+        monkeypatch.setenv("TAYAVISION_RESUME", "auto")
+        monkeypatch.setenv("SAVE_CKPT_DIR", "gs://bucket/ckpts")
+        listing = (
+            "  69294193  2026-07-25T19:38:00Z  gs://bucket/ckpts/old-run/checkpoint_4360.pt\n"
+            "  69294193  2026-07-26T01:35:37Z  gs://bucket/ckpts/new-run/checkpoint_8.pt\n"
+            "TOTAL: 2 objects, 138588386 bytes (132.17MiB)\n"
+        )
+        with mock.patch.object(utils, "_gcloud_storage",
+                               return_value=(True, listing, "")):
+            assert utils.resolve_resume_run_id() == "new-run"
+
+    def test_auto_ignores_total_summary_line(self, monkeypatch):
+        """The `TOTAL:` footer has no gs:// field and must not be parsed."""
+        monkeypatch.setenv("TAYAVISION_RESUME", "auto")
+        monkeypatch.setenv("SAVE_CKPT_DIR", "gs://bucket/ckpts")
+        listing = "TOTAL: 0 objects, 0 bytes (0B)\n"
+        with mock.patch.object(utils, "_gcloud_storage",
+                               return_value=(True, listing, "")):
+            assert utils.resolve_resume_run_id() is None
+
+    def test_auto_on_empty_prefix_starts_fresh(self, monkeypatch):
+        monkeypatch.setenv("TAYAVISION_RESUME", "auto")
+        monkeypatch.setenv("SAVE_CKPT_DIR", "gs://bucket/ckpts")
+        with mock.patch.object(utils, "_gcloud_storage",
+                               return_value=(False, "", "matched no objects")):
+            assert utils.resolve_resume_run_id() is None
+
+
+class TestSaveCheckpointIntegration:
+    """`save_checkpoint` must mirror exactly what it wrote, once."""
+
+    def _args(self, ckpt_dir):
+        projector = __import__("torch").nn.Linear(2, 2)
+        model = mock.Mock()
+        model.multi_modal_projector = projector
+        model._orig_mod = None
+        del model._orig_mod  # keep _unwrap_model from following a Mock
+        del model.module
+        opt = mock.Mock()
+        opt.state_dict.return_value = {}
+        sched = mock.Mock()
+        sched.state_dict.return_value = {}
+        return ckpt_dir, 40, model, opt, sched
+
+    def test_mirrors_after_local_write(self, ckpt_dir, monkeypatch):
+        monkeypatch.setenv("SAVE_CKPT_DIR", "gs://bucket/ckpts")
+        args = self._args(ckpt_dir)
+        with mock.patch.object(utils, "mirror_checkpoint_to_gcs") as m:
+            utils.save_checkpoint(*args)
+        expected = ckpt_dir / "checkpoint_40.pt"
+        assert expected.exists(), "local checkpoint must still be written"
+        m.assert_called_once_with(expected)
+
+    def test_only_the_writer_mirrors(self, ckpt_dir, monkeypatch):
+        """On a non-writing rank nothing is uploaded -- otherwise N hosts race
+        to write the same object."""
+        monkeypatch.setenv("SAVE_CKPT_DIR", "gs://bucket/ckpts")
+        backend = mock.Mock()
+        backend.is_main = False
+        args = self._args(ckpt_dir)
+        with mock.patch.object(utils, "mirror_checkpoint_to_gcs") as m:
+            utils.save_checkpoint(*args, backend=backend)
+        backend.save.assert_called_once()
+        m.assert_not_called()


### PR DESCRIPTION
## What this is

Tiny Aya Vision Phase 1 alignment now runs end to end on a Cloud TPU, from the
**same** `pipeline/train_alignment.py` that runs on Modal. A full epoch completed on a
v6e-16 and the trained projector is in GCS.

**The Modal/GPU path is unchanged and remains authoritative.** `pytest` on the GPU path is
byte-equivalent: 121 passed / 8 gated-repo errors before and after, plus 31 new tests here.

> **Status: this is a checkpoint of a workstream, not a finished feature.** The TRC grant
> ended 2026-07-26. **I will pick this branch back up when I have TPU compute again.**
> Merging is not urgent; review comments are very welcome in the meantime.

## The result

**W&B run: https://wandb.ai/cataluna84/tayavision-tpu/runs/e93fe1cd684c4c0f925bad9eeb38ddf1**

| Metric | Value |
|---|---|
| `train/loss` | 9.053 → **2.367** |
| Optimizer steps | 2,180 (a full epoch over 558,128 LLaVA-Pretrain samples) |
| Wall clock | **59 min 08 s** |
| `perf/step_time` | p50 **1.508 s**, p90 1.516 s |
| `perf/images_per_sec` | 169.2 |
| `mem/used_gib` | 23.13 – **27.86** of 31.246 |
| `xla/compile_cause_count` | **`[1]` — a single distinct value across all 2,180 steps** |
| `train/max_image_tokens` | **196** every step (the SigLIP invariant) |

That flat compile counter is the line that matters. On XLA every distinct tensor shape is a
new HLO compile, so with dynamic padding the number climbs forever. `[1]` across a whole
epoch is what proves the fixed-sequence-length collate works.

**Effective batch is 256, deliberately identical to the Modal GPU baseline** (there
`batch_size=8 x grad_acc=32`; here `128 x 2`). LR 1e-3, `warmup_ratio` 0.03 and the cosine
schedule are therefore **unchanged**, which is what makes this loss curve comparable to the
GPU one rather than merely plausible.

Trained weights:
`gs://tayavision-eu/checkpoints/v6e16-align-01/e93fe1cd-684c-4c0f-925b-ad9eeb38ddf1/checkpoint_4360.pt`
— 11,547,648 params, bf16, **CPU-resident so it loads on CUDA with no conversion**, 0 NaNs.
`config/training/instruct.yaml` already has an `alignment_checkpoint` hook, so Phase 2 can
pick it up with a one-line override.

## How to review this

The eight commits are ordered so each is coherent on its own; reviewing in order is much
easier than reading the squashed diff.

| # | Commit | What to look at |
|---|---|---|
| 1 | `Add ruff/pytest config and clear the 76-finding lint baseline` | Mechanical. Skim it. The only judgement calls are the E402 `per-file-ignores` and the `# noqa: F401` on the `models` imports — both load-bearing, both explained in the message. |
| 2 | `Add project guide and the .claude external memory system` | Docs and tooling. `.gitignore` gains `!.claude/settings.json` because the blanket `*.json` would otherwise hide it. |
| 3 | `Add src/backend accelerator seam with a CI guard` | **The design decision.** Worth the most attention. |
| 4 | `Add TPU run control: provisioning, deploy, staging, ops` | Shell only, touches no training code. |
| 5 | `Make checkpoints durable: gs:// write-through and resume` | Self-contained + 31 tests. |
| 6 | `Run alignment on TPU: convert to the seam and fix XLA correctness` | **The substantive change**, and where the six silent bugs were fixed. |
| 7 | `Stop train_multilingual hardcoding the W&B project` | Three lines, but it prevented a bring-up run writing into a results project. |
| 8 | `Add the TPU run record and resume guide` | `docs/tpu_alignment_handoff_2026-07.md` — read this first if you only read one thing. |

## Why a seam instead of inline TPU support

`pipeline/train_*.py` was DDP+CUDA throughout. Adding `if torch_xla` branches into the
training loop breaks the Modal path for everyone the first time one of them is wrong.

`src/backend/` is a `Backend` ABC with two implementations. `GPUBackend` is the existing
logic extracted verbatim. `TPUBackend` is the **only** module permitted a module-level
`import torch_xla`, and `scripts/ci/check_backend_seam.sh` greps `src/ models/ pipeline/
config/ evaluation/` and fails the build otherwise — so the seam cannot rot quietly.

## The bugs, because none of them raised

Every failure below was silent. That is the theme of this branch and the reason the commit
messages are long: each one is written as a **recognisable log signature**, so the next
person matches symptoms instead of re-deriving the cause.

1. **`if is_main:` around device work deadlocks SPMD.** Any device→host read (`.item()`,
   `.cpu()`, `state_dict()`) forces a graph execution every host must join, so gating one on
   rank desynchronises the mesh. Rank 0 sat in `pn.std().item()` inside the W&B block while
   ranks 1–3 had raced into the next forward. All four idle in `futex_wait_queue`, HBM
   resident, duty cycle 0%, **no traceback, for 2 h 39 min**. `py-spy dump --pid` on every
   host and comparing where the MainThreads sit is what actually diagnosed it.
   *Corollary:* **do not use `xm.save`** — it does
   `_maybe_convert_to_cpu(data, convert=should_write_data)`, i.e. it transfers only on the
   writer, the same asymmetry. Its docstring compensates by suggesting `xm.rendezvous`
   afterwards, but a barrier cannot repair a mismatch in the collective work itself.
2. **Host-sharded input needs `ShardingSpec(minibatch=True)`.** Otherwise every host claims
   its own 64 rows are the global tensor to split across 16 chips. Nothing raises — 64
   divides 16, every shape check passes — and the program simply never progresses.
3. **`MpDeviceLoader` does not shard.** `parallel_loader.py` contains no `process_index`,
   `process_count`, or any `xr.*` call. It applies a `ShardingSpec` if you give it one and
   never infers one.
4. **`xr.world_size()` returns 1 and `xr.global_ordinal()` returns 0 on every host** under
   SPMD. Host sharding built on them is a silent no-op; use `process_count`/`process_index`.
5. **`drop_last=False` is fatal, not just wasteful** — the short final batch is both a new
   shape and not divisible by the local chip count, so it raises at the *end* of an
   otherwise complete epoch.
6. **`torch.load(map_location=<xla device>)` raises**, and the `tagged with xla:0` in the
   message names the *target*, not the file.

Two environment knobs also read as wired and were not: `SAVE_CKPT_DIR` reached only the
shell scripts, and `TAYAVISION_RESUME` was only echoed into a log banner. Both are live now.
**When auditing this repo's env knobs, grep for a consumer, not for the assignment.**

## Verified rather than asserted

Durability was tested by **deleting `/models/<run_id>` on all four hosts** and resuming from
the bucket alone. That is what exposed bugs 6 and the resume step double-count — neither is
visible without a real recycle. "It writes to `gs://`" and "it survives a preemption" are
different claims.

## TRC capacity, for anyone planning a bigger run

Five provisioning attempts, zone clean before each, quota ruled out
(`IN_USE_ADDRESSES` 16/64):

| Profile | Attempts | Outcome |
|---|---|---|
| `v6e-64-ew4a` | 3 | all FAILED |
| `v6e-32-ew4a` | 2 | all FAILED |
| `v6e-16-ew4a` | 3 | **all ACTIVE**, ~4–6 min |

All failures identical: `WAITING_FOR_RESOURCES → PROVISIONING → SUSPENDING → FAILED`,
`{"code": 13, "message": "an internal error has occurred"}`. Read `code 13` as *no capacity
at this slice size*, not as a bug — the service accepts, begins allocating, then withdraws,
and a failed QR terminates rather than staying queued, so waiting is not a strategy.
**16 chips was the practical ceiling.**

## Known gaps

- `train_instruct.py` / `train_multilingual.py` are **not** converted to the seam; they are
  still DDP+CUDA and will not run on TPU.
- No eval number was produced from the TPU-trained projector — the loss fell, but nothing
  was benchmarked against it.
- Generation is disabled on TPU by design (`DynamicCache` grows per token, so each token is
  a new HLO).
- MoonViT emits a variable token count per image, which is unbounded recompilation on XLA;
  that experiment belongs on the Modal path.
- The `index_put`/`nonzero` image merge wants opposite code on the two backends and should
  move behind the seam.
- **The analytical activation model was wrong four times, always low.** Size batches by
  bisection and read `mem/used_gib`; treat any formula as an order-of-magnitude check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
